### PR TITLE
Fix: Resolve icon and text overlap on Auth pages

### DIFF
--- a/src/styles/AuthPages.css
+++ b/src/styles/AuthPages.css
@@ -197,7 +197,7 @@
 
 .auth-form__input {
     width: 100%;
-    padding: 12px 16px 12px 40px;
+    padding: 12px 16px 12px 44px !important;
     border: 1px solid var(--border-default);
     border-radius: 12px;
     font-size: 15px;

--- a/src/styles/AuthPages.css
+++ b/src/styles/AuthPages.css
@@ -191,17 +191,21 @@
     top: 50%;
     transform: translateY(-50%);
     color: var(--gray-400);
+    pointer-events: none;
+    z-index: 1;
 }
 
 .auth-form__input {
     width: 100%;
-    padding: 12px 16px 12px 44px;
+    padding: 12px 16px 12px 40px;
     border: 1px solid var(--border-default);
     border-radius: 12px;
     font-size: 15px;
     color: var(--gray-900);
     background: white;
     transition: all 0.2s ease;
+    position: relative;
+    z-index: 0;
 }
 
 .auth-form__input:focus {


### PR DESCRIPTION
## 🐛 What's changed
Ah! I noticed that on the Login and Signup pages, the input icons (Email and Password) were overlapping with the typed text, making it unreadable. 

Fix #8 

This PR fixes that issue by:
1. Adding `pointer-events: none` to the icons, ensuring they don't block clicks on the input field.
2. Properly managing the `z-index` so the icon text remains at the back.
3. Enforcing the left-padding (`padding-left: 44px !important`) to make sure the text reliably starts *after* the icon.

## 🛠️ Files changed
- [src/styles/AuthPages.css](cci:7://file:///home/rudra/flowconnect/src/styles/AuthPages.css:0:0-0:0)


- **Before:** The text `you@example.com` was starting from the far left under the icon.
- **After:** Text is nicely padded and perfectly readable!

Resolves #<Insert-Issue-Number-Here-if-you-raised-one>
