### PR TITLE
[BUG FIX] Aligned the first section in 'How It Works' page

### DIFF
--- a/src/pages/HowItWorksPage.tsx
+++ b/src/pages/HowItWorksPage.tsx
@@ -19,7 +19,7 @@ export default function HowItWorksPage() {
                             initial={{ opacity: 0, y: 20 }}
                             animate={{ opacity: 1, y: 0 }}
                             transition={{ duration: 0.6 }}
-                            style={{ textAlign: 'center', maxWidth: '800px', margin: '0 auto' }}
+                            style={{ textAlign: 'center', maxWidth: '640px', margin: '0 auto 20px' }}
                         >
                             <div className="section-badge" style={{ margin: '0 auto 20px' }}>
                                 <GitBranch size={14} />


### PR DESCRIPTION
## Summary

The section subtitle of the first section in the 'How It works' page was not centered properly. It was fixed by matching the maxWidth with the class properties. 

## Testing

- [x] `npm run lint`
- [x] `npm run build`

(No issues come up that are related to the changes made in this commit)

## Notes

**Before**

<img width="1298" height="422" alt="Screenshot 2026-04-14 111033" src="https://github.com/user-attachments/assets/c8a106ab-0f1e-45c1-8333-4bd0e9fe6ed4" />

**After**

<img width="1296" height="785" alt="image" src="https://github.com/user-attachments/assets/170ad8f4-fd3d-48ee-91a1-fb7bd06564b9" />
