### PR TITLE
feat: Add Live Stats on Homepage (#38)

### DIFF
--- a/flowconnect/auth-backend/auth-server.js
+++ b/flowconnect/auth-backend/auth-server.js
@@ -141,6 +141,26 @@ async function computeDashboard(userId) {
   };
 }
 
+async function computeGlobalStats() {
+  const users = await readUsers();
+  const workflows = await readWorkflows();
+  const apps = await readApps();
+
+  const totalExecutions = workflows.reduce((sum, w) => sum + (w.run_count || 0), 0);
+  const successfulExecutions = workflows.reduce((sum, w) => sum + (w.successful_run_count || 0), 0);
+  const successRate = totalExecutions > 0 
+    ? Math.round((successfulExecutions / totalExecutions) * 100) 
+    : 100;
+
+  return {
+    total_users: users.length,
+    active_flows: workflows.filter(w => w.status === "active").length,
+    total_executions: totalExecutions,
+    success_rate: successRate,
+    uptime_percentage: 99.9,
+  };
+}
+
 async function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization || "";
   const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
@@ -340,6 +360,22 @@ app.delete("/api/apps/:appName", authMiddleware, async (req, res) => {
 app.get("/api/dashboard/", authMiddleware, async (req, res) => {
   const dashboard = await computeDashboard(req.user.id);
   return res.json(dashboard);
+});
+
+app.get("/api/stats/public", async (_req, res) => {
+  try {
+    const stats = await computeGlobalStats();
+    return res.json(stats);
+  } catch (error) {
+    console.error("Error computing global stats:", error);
+    return res.json({
+      total_users: 0,
+      active_flows: 0,
+      total_executions: 0,
+      success_rate: 100,
+      uptime_percentage: 99.9,
+    });
+  }
 });
 
 app.listen(PORT, () => {

--- a/src/components/sections/LiveStats.css
+++ b/src/components/sections/LiveStats.css
@@ -1,0 +1,189 @@
+.live-stats {
+  position: relative;
+  padding: 80px 0;
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.live-stats__header {
+  text-align: center;
+  margin-bottom: 60px;
+}
+
+/* Stats Grid */
+.live-stats__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 24px;
+  margin-bottom: 40px;
+}
+
+.live-stats__card {
+  position: relative;
+  padding: 24px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+}
+
+.live-stats__card:hover {
+  border-color: rgba(255, 255, 255, 1);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
+  transform: translateY(-5px);
+}
+
+/* Color variants */
+.live-stats__card--blue {
+  border-left: 4px solid #3b82f6;
+}
+
+.live-stats__card--blue .live-stats__card-icon {
+  background: rgba(59, 130, 246, 0.1);
+  color: #3b82f6;
+}
+
+.live-stats__card--amber {
+  border-left: 4px solid #f59e0b;
+}
+
+.live-stats__card--amber .live-stats__card-icon {
+  background: rgba(245, 158, 11, 0.1);
+  color: #f59e0b;
+}
+
+.live-stats__card--green {
+  border-left: 4px solid #10b981;
+}
+
+.live-stats__card--green .live-stats__card-icon {
+  background: rgba(16, 185, 129, 0.1);
+  color: #10b981;
+}
+
+.live-stats__card--purple {
+  border-left: 4px solid #8b5cf6;
+}
+
+.live-stats__card--purple .live-stats__card-icon {
+  background: rgba(139, 92, 246, 0.1);
+  color: #8b5cf6;
+}
+
+.live-stats__card-icon {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+.live-stats__card-content {
+  position: relative;
+  z-index: 2;
+}
+
+.live-stats__card-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 4px;
+}
+
+.live-stats__card-label {
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+/* Loading State */
+.live-stats__loading {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 24px;
+  margin-bottom: 40px;
+}
+
+.skeleton-bar {
+  height: 120px;
+  background: linear-gradient(90deg, #f0f0f0 0%, #e0e0e0 50%, #f0f0f0 100%);
+  background-size: 200% 100%;
+  border-radius: 12px;
+  animation: loading 1.5s infinite;
+}
+
+@keyframes loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Updated timestamp */
+.live-stats__updated {
+  text-align: center;
+  font-size: 12px;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .live-stats {
+    padding: 60px 0;
+  }
+
+  .live-stats__grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
+
+  .live-stats__card {
+    padding: 16px;
+  }
+
+  .live-stats__card-value {
+    font-size: 22px;
+  }
+
+  .live-stats__card-icon {
+    width: 40px;
+    height: 40px;
+  }
+
+  .skeleton-bar {
+    height: 100px;
+  }
+}
+
+@media (max-width: 480px) {
+  .live-stats__grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .live-stats__card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+  }
+
+  .live-stats__card-icon {
+    flex-shrink: 0;
+    margin-bottom: 0;
+  }
+
+  .live-stats__card-value {
+    font-size: 18px;
+  }
+
+  .skeleton-bar {
+    height: 80px;
+  }
+}

--- a/src/components/sections/LiveStats.tsx
+++ b/src/components/sections/LiveStats.tsx
@@ -1,0 +1,156 @@
+import { motion, useInView } from 'framer-motion'
+import { useRef, useState, useEffect } from 'react'
+import { Users, Zap, TrendingUp, Gauge } from 'lucide-react'
+import './LiveStats.css'
+
+interface Stats {
+  total_users: number
+  active_flows: number
+  total_executions: number
+  success_rate: number
+  uptime_percentage: number
+}
+
+export default function LiveStats() {
+  const ref = useRef(null)
+  const isInView = useInView(ref, { once: false, margin: '-100px' })
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+
+  const fetchStats = async () => {
+    try {
+      const AUTH_BASE = import.meta.env.VITE_AUTH_API_BASE_URL || 'http://localhost:4000'
+      const response = await fetch(`${AUTH_BASE}/api/stats/public`)
+      
+      if (response.ok) {
+        const data = await response.json()
+        setStats(data)
+        setLastUpdated(new Date())
+      }
+    } catch (err) {
+      console.error('Error fetching stats:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchStats()
+  }, [])
+
+  useEffect(() => {
+    if (!isInView) return
+    
+    const interval = setInterval(() => {
+      fetchStats()
+    }, 30000)
+
+    return () => clearInterval(interval)
+  }, [isInView])
+
+  const statItems = [
+    {
+      label: 'Active Users',
+      value: stats?.total_users || 0,
+      icon: Users,
+      color: 'blue',
+    },
+    {
+      label: 'Active Flows',
+      value: stats?.active_flows || 0,
+      icon: Zap,
+      color: 'amber',
+    },
+    {
+      label: 'Workflows Executed',
+      value: stats?.total_executions || 0,
+      icon: TrendingUp,
+      color: 'green',
+    },
+    {
+      label: 'Success Rate',
+      value: (stats?.success_rate || 100) + '%',
+      icon: Gauge,
+      color: 'purple',
+    },
+  ]
+
+  return (
+    <section className="live-stats section" id="live-stats" ref={ref}>
+      <div className="container">
+        <motion.div
+          className="live-stats__header"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+        >
+          <div className="section-badge">
+            <Zap size={14} />
+            Live Activity
+          </div>
+          <h2 className="section-title">
+            Platform <span className="gradient-text">Live Statistics</span>
+          </h2>
+        </motion.div>
+
+        {!loading && stats ? (
+          <motion.div
+            className="live-stats__grid"
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+          >
+            {statItems.map((item, i) => {
+              const IconComponent = item.icon
+              return (
+                <motion.div
+                  key={i}
+                  className={`live-stats__card live-stats__card--${item.color}`}
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  whileInView={{ opacity: 1, scale: 1 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.4, delay: i * 0.1 }}
+                  whileHover={{ y: -5 }}
+                >
+                  <div className="live-stats__card-icon">
+                    <IconComponent size={24} />
+                  </div>
+                  <div className="live-stats__card-content">
+                    <div className="live-stats__card-value">
+                      {typeof item.value === 'number' 
+                        ? item.value.toLocaleString() 
+                        : item.value}
+                    </div>
+                    <div className="live-stats__card-label">{item.label}</div>
+                  </div>
+                </motion.div>
+              )
+            })}
+          </motion.div>
+        ) : (
+          <div className="live-stats__loading">
+            <div className="skeleton-bar" />
+            <div className="skeleton-bar" />
+            <div className="skeleton-bar" />
+            <div className="skeleton-bar" />
+          </div>
+        )}
+
+        {lastUpdated && (
+          <motion.p
+            className="live-stats__updated"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6, delay: 0.3 }}
+          >
+            Updated: {lastUpdated.toLocaleTimeString()} · Refreshes every 30 seconds
+          </motion.p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import Navbar from '../components/common/Navbar'
 import Hero from '../components/sections/Hero'
+import LiveStats from '../components/sections/LiveStats'
 import Features from '../components/sections/Features'
 import HowItWorks from '../components/sections/HowItWorks'
 import LearnAutomation from '../components/sections/LearnAutomation'
@@ -15,6 +16,7 @@ export default function HomePage() {
             <Navbar />
             <main>
                 <Hero />
+                <LiveStats />
                 <Features />
                 <HowItWorks />
                 <LearnAutomation />


### PR DESCRIPTION
Closes #38

## Changes
- Added /api/stats/public endpoint for platform-wide statistics
- Created LiveStats component with real-time updates
- Auto-refreshes every 30 seconds
- Fully responsive design with loading skeleton states
- Integrated into homepage between Hero and Features sections

<img width="1920" height="1020" alt="Screenshot 2026-04-21 140623" src="https://github.com/user-attachments/assets/2d8fa635-7dfd-4320-9ec3-8cdd2bc94faf" />
