### PR TITLE
fix(fast2sms): resolve silent failures and migrate to MCP server

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import express from "express";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import fast2smsRoute from "./src/server/fast2sms-route.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,7 +10,12 @@ const port = Number(process.env.PORT) || 3000;
 const distPath = path.join(__dirname, "dist");
 
 app.use(express.static(distPath));
+app.use(express.json());
 
+// ── Fast2SMS route only ────────────────────────────────────────────────────
+app.use("/api", fast2smsRoute);
+
+// ── Fallback to index.html for SPA ──────────────────────────────────────────
 app.get(/.*/, (_req, res) => {
   res.sendFile(path.join(distPath, "index.html"));
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -30,5 +30,14 @@ export async function getMe() {
 
 export async function apiCall(endpoint: string, options: RequestInit & { skipAuth?: boolean } = {}) {
     const url = `${AUTH_BASE}/api${endpoint}`
-    return http.post(url, options.body ? JSON.parse(options.body as string) : {}, options)
+    const method = (options.method || 'POST').toUpperCase()
+    const body = options.body ? JSON.parse(options.body as string) : undefined
+
+    if (method === 'GET') return http.get(url, options)
+    if (method === 'POST') return http.post(url, body, options)
+    if (method === 'PUT') return http.put(url, body, options)
+    if (method === 'PATCH') return http.patch(url, body, options)
+    if (method === 'DELETE') return http.delete(url, options)
+
+    throw new Error(`Unsupported method: ${method}`)
 }

--- a/src/api/fast2sms.ts
+++ b/src/api/fast2sms.ts
@@ -1,59 +1,20 @@
-const API_KEY = import.meta.env.VITE_FAST2SMS_API_KEY
+import { http } from './httpClient'
 
 export async function sendSMS(params: {
   numbers: string        // '9876543210' or '9876543210,9123456789'
   message: string
   sender_id?: string
 }) {
-  const cleaned = params.numbers.replace(/\s/g, '')
-
-  const body = new URLSearchParams({
-    route: 'q',
-    numbers: cleaned,
+  const response = await http.post('/api/sms', {
+    numbers: params.numbers,
     message: params.message,
-    flash: '0',
-  })
-  if (params.sender_id) body.set('sender_id', params.sender_id)
+    sender_id: params.sender_id,
+  }, { skipAuth: true })
 
-  const res = await fetch('https://www.fast2sms.com/dev/bulkV2', {
-    method: 'POST',
-    headers: {
-      authorization: API_KEY,
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'cache-control': 'no-cache',
-    },
-    body: body.toString(),
-  })
-
-  const data = await res.json()
-  if (!data.return) throw new Error(`Fast2SMS error: ${JSON.stringify(data)}`)
-
-  const count = cleaned.split(',').length
-  return {
-    success: true,
-    request_id: data.request_id,
-    message: `SMS sent to ${cleaned}`,
-    numbers_count: count,
-    estimated_cost: `Rs.${(count * 0.15).toFixed(2)}`,
-  }
+  return response
 }
 
 export async function checkBalance() {
-  const res = await fetch('https://www.fast2sms.com/dev/wallet', {
-    method: 'GET',
-    headers: {
-      authorization: API_KEY,
-      'cache-control': 'no-cache',
-    },
-  })
-
-  const data = await res.json()
-  if (!data.return) throw new Error(`Fast2SMS wallet error: ${JSON.stringify(data)}`)
-
-  return {
-    success: true,
-    wallet_balance: `Rs.${data.wallet}`,
-    sms_remaining: Math.floor(data.wallet / 0.15),
-    message: `Rs.${data.wallet} remaining (~${Math.floor(data.wallet / 0.15)} SMS)`,
-  }
+  const response = await http.get('/api/sms/balance', { skipAuth: true })
+  return response
 }

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -67,6 +67,13 @@ export const http = {
       body: body ? JSON.stringify(body) : undefined,
     }),
 
+  patch: <T = any>(url: string, body?: any, options?: RequestInit & { skipAuth?: boolean }) =>
+    httpFetch<T>(url, {
+      ...options,
+      method: 'PATCH',
+      body: body ? JSON.stringify(body) : undefined,
+    }),
+
   delete: <T = any>(url: string, options?: RequestInit & { skipAuth?: boolean }) =>
     httpFetch<T>(url, { ...options, method: 'DELETE' }),
 }

--- a/src/pages/BuilderPage.tsx
+++ b/src/pages/BuilderPage.tsx
@@ -370,7 +370,7 @@ export default function BuilderPage() {
 
     function showToast(msg: string, type: 'success' | 'error') {
         setToast({ msg, type })
-        setTimeout(() => setToast(null), 3500)
+        setTimeout(() => setToast(null), 6000)
     }
 
     function addAction(action: typeof actions[0]) {
@@ -807,7 +807,12 @@ export default function BuilderPage() {
         if (!toNumber) return
         try {
             const cleaned = toNumber.replace('+91', '').replace(/\s/g, '').trim()
-            if (cleaned.length !== 10) return
+            if (cleaned.length !== 10) {
+                const msg = `Invalid SMS number: ${cleaned || 'empty'}`
+                console.warn('[SMS] Invalid phone number:', cleaned)
+                showToast(msg, 'error')
+                return
+            }
             const smsText = status === 'Success'
                 ? messageTemplate
                     .replace('{name}', 'Customer')
@@ -815,8 +820,14 @@ export default function BuilderPage() {
                     .replace('{payment_id}', workflowId)
                     .replace('{phone}', cleaned)
                 : `Pravah: Workflow "${workflowName}" failed to deploy.`
-            await sendSMS({ numbers: cleaned, message: smsText })
-        } catch {}
+
+            const result = await sendSMS({ numbers: cleaned, message: smsText })
+            console.log('[SMS] Sent successfully:', result)
+        } catch (err: any) {
+            const message = err?.message || 'SMS failed'
+            console.error('[SMS] Failed to send:', message)
+            showToast(`SMS failed: ${message}`, 'error')
+        }
     }
 
     // ── Save ──────────────────────────────────────────────────────────────────

--- a/src/server/fast2sms-route.js
+++ b/src/server/fast2sms-route.js
@@ -1,0 +1,247 @@
+import express from "express";
+import { spawn } from "child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const router = express.Router();
+
+router.post("/sms", async (req, res) => {
+  const { numbers, message, sender_id } = req.body;
+
+  if (!numbers || !message) {
+    return res.status(400).json({ error: "numbers and message are required" });
+  }
+
+  const cleaned = numbers
+    .split(",")
+    .map((n) => n.trim().replace(/^\+91/, "").replace(/\D/g, ""))
+    .join(",");
+
+  try {
+    const result = await callFast2SMSMCP(cleaned, message, sender_id);
+    return res.json(result);
+  } catch (err) {
+    console.error("[SMS] Error:", err.message);
+    return res.status(500).json({ detail: err.message });
+  }
+});
+
+router.get("/sms/balance", async (_req, res) => {
+  try {
+    const result = await callFast2SMSMCPBalance();
+    return res.json(result);
+  } catch (err) {
+    console.error("[SMS Balance] Error:", err.message);
+    return res.status(500).json({ detail: err.message });
+  }
+});
+
+function callFast2SMSMCP(numbers, message, sender_id) {
+  return new Promise((resolve, reject) => {
+    const mcpPath = path.join(__dirname, "../../flowconnect/fast2sms-mcp/index.js");
+    const child = spawn("node", [mcpPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let buffer = "";
+    let initialized = false;
+    let done = false;
+
+    child.stdin.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          clientInfo: { name: "pravah-server", version: "1.0.0" },
+          capabilities: {},
+        },
+      }) + "\n"
+    );
+
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop();
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+
+          if (!initialized && msg.id === 1 && msg.result?.serverInfo) {
+            initialized = true;
+            const smsCall = JSON.stringify({
+              jsonrpc: "2.0",
+              id: 2,
+              method: "tools/call",
+              params: {
+                name: "send_sms",
+                arguments: {
+                  numbers,
+                  message,
+                  ...(sender_id && { sender_id }),
+                },
+              },
+            });
+            child.stdin.write(smsCall + "\n");
+            return;
+          }
+
+          if (initialized && msg.id === 2 && !done) {
+            done = true;
+            child.kill();
+            if (msg.error) {
+              reject(new Error(msg.error.message || "SMS failed"));
+            } else if (msg.result?.isError) {
+              let errorMsg = msg.result.content[0].text;
+              try {
+                const jsonStart = errorMsg.indexOf('{');
+                if (jsonStart !== -1) {
+                  const jsonStr = errorMsg.substring(jsonStart);
+                  const parsed = JSON.parse(jsonStr);
+                  if (parsed.message) {
+                    errorMsg = parsed.message;
+                  }
+                }
+              } catch (e) {
+                // Ignore parse errors, fallback to original message
+              }
+              errorMsg = errorMsg.replace(/^Error:\s*/, '').replace(/^Fast2SMS API error:\s*/, '');
+              reject(new Error(errorMsg));
+            } else {
+              try {
+                resolve(JSON.parse(msg.result.content[0].text));
+              } catch (e) {
+                resolve({ success: true, raw: msg.result.content[0].text });
+              }
+            }
+          }
+        } catch {
+          // Ignore non-JSON output from the child process.
+        }
+      }
+    });
+
+    child.stderr.on("data", (chunk) => {
+      console.error("[MCP stderr]:", chunk.toString());
+    });
+
+    child.on("close", (code) => {
+      if (!done) {
+        done = true;
+        reject(new Error(`MCP process exited with code ${code}`));
+      }
+    });
+
+    child.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+function callFast2SMSMCPBalance() {
+  return new Promise((resolve, reject) => {
+    const mcpPath = path.join(__dirname, "../../flowconnect/fast2sms-mcp/index.js");
+    const child = spawn("node", [mcpPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let buffer = "";
+    let initialized = false;
+    let done = false;
+
+    child.stdin.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          clientInfo: { name: "pravah-server", version: "1.0.0" },
+          capabilities: {},
+        },
+      }) + "\n"
+    );
+
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop();
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+
+          if (!initialized && msg.id === 1 && msg.result?.serverInfo) {
+            initialized = true;
+            const balanceCall = JSON.stringify({
+              jsonrpc: "2.0",
+              id: 2,
+              method: "tools/call",
+              params: {
+                name: "check_balance",
+                arguments: {},
+              },
+            });
+            child.stdin.write(balanceCall + "\n");
+            return;
+          }
+
+          if (initialized && msg.id === 2 && !done) {
+            done = true;
+            child.kill();
+            if (msg.error) {
+              reject(new Error(msg.error.message || "Balance check failed"));
+            } else if (msg.result?.isError) {
+              let errorMsg = msg.result.content[0].text;
+              try {
+                const jsonStart = errorMsg.indexOf('{');
+                if (jsonStart !== -1) {
+                  const jsonStr = errorMsg.substring(jsonStart);
+                  const parsed = JSON.parse(jsonStr);
+                  if (parsed.message) {
+                    errorMsg = parsed.message;
+                  }
+                }
+              } catch (e) {
+                // Ignore parse errors, fallback to original message
+              }
+              errorMsg = errorMsg.replace(/^Error:\s*/, '').replace(/^Fast2SMS API error:\s*/, '');
+              reject(new Error(errorMsg));
+            } else {
+              try {
+                resolve(JSON.parse(msg.result.content[0].text));
+              } catch (e) {
+                resolve({ success: true, raw: msg.result.content[0].text });
+              }
+            }
+          }
+        } catch {
+          // Ignore non-JSON output from the child process.
+        }
+      }
+    });
+
+    child.stderr.on("data", (chunk) => {
+      console.error("[MCP stderr]:", chunk.toString());
+    });
+
+    child.on("close", (code) => {
+      if (!done) {
+        done = true;
+        reject(new Error(`MCP process exited with code ${code}`));
+      }
+    });
+
+    child.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+export default router;


### PR DESCRIPTION
- Migrated `fast2sms.ts` API calls from client-side direct requests to the `/api/sms` backend route, securely utilizing the Fast2SMS MCP child process.
- Updated `fast2sms-route.js` to correctly catch and parse JSON-RPC `isError` responses from the MCP server.
- Extracted human-readable error messages from stringified JSON responses to prevent ugly object rendering in the UI.
- Ensured backend properly rejects promises and returns appropriate HTTP error statuses (e.g., 500) so the frontend HTTP client correctly registers the network failure.
- Increased UI toast duration from 3.5s to 6s in `BuilderPage.tsx` to give users sufficient time to read the detailed API failure messages.

Fixes: SMS failing silently without throwing errors in the UI.

## Summary

Describe the change in a few sentences.

## Testing

- [x] `npm run lint`
- [x] `npm run build`

## Notes

Mention screenshots, environment changes, or follow-up work if needed.

<img width="1920" height="983" alt="Screenshot (2461)" src="https://github.com/user-attachments/assets/9cb0e361-263f-48e9-b0cf-1b350d6665a9" />
