### PR TITLE
fix: improve login page text contrast in dark mode

### DIFF
--- a/src/styles/AuthPages.css
+++ b/src/styles/AuthPages.css
@@ -52,7 +52,6 @@
     border: 1px solid var(--border-default);
     border-radius: 24px;
     box-shadow: 0 20px 60px -10px rgba(0, 0, 0, 0.08);
-    /* Soft shadow */
     position: relative;
     z-index: 10;
 }
@@ -115,7 +114,6 @@
     background: white;
     color: var(--primary-600);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    /* Slight lift */
 }
 
 .auth-tabs__btn--active:hover {
@@ -255,4 +253,56 @@
     color: var(--gray-500);
     font-size: 13px;
     font-weight: 500;
+}
+
+/* =========================================
+   DARK MODE FIXES — LOGIN PAGE ONLY
+   ========================================= */
+
+html[data-theme="dark"] .auth-card {
+    background: #111827;
+    border-color: #374151;
+}
+
+html[data-theme="dark"] .auth-card__title {
+    color: #f9fafb;
+}
+
+html[data-theme="dark"] .auth-card__subtitle {
+    color: #cbd5e1;
+}
+
+html[data-theme="dark"] .auth-form__label {
+    color: #e5e7eb;
+}
+
+html[data-theme="dark"] .auth-form__forgot {
+    color: #cbd5e1;
+}
+
+html[data-theme="dark"] .auth-form__input {
+    background: #0f172a;
+    color: #f8fafc;
+    border-color: #334155;
+}
+
+html[data-theme="dark"] .auth-form__input::placeholder {
+    color: #94a3b8;
+}
+
+html[data-theme="dark"] .auth-form__input-icon {
+    color: #cbd5e1;
+}
+
+html[data-theme="dark"] .auth-form__toggle-pw {
+    color: #cbd5e1;
+}
+
+html[data-theme="dark"] .auth-card__footer {
+    border-color: #374151;
+    color: #cbd5e1;
+}
+
+html[data-theme="dark"] .auth-page__trust {
+    color: #e2e8f0;
 }


### PR DESCRIPTION
## Summary

Improved text contrast and readability for the login page in dark mode.

Updated dark mode styles for headings, labels, placeholders, input text, and footer content while preserving the existing light mode UI and overall design consistency.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #99

## Changes Made

- Improved login page text visibility in dark mode
- Updated label, placeholder, and footer text contrast
- Enhanced input field readability in dark theme
- Preserved existing light mode appearance
- Maintained current layout and component structure

## Testing

- [ ] `npm run lint`
- [ ] `npm run build`

## Notes

- Changes are scoped only to login/auth page dark mode styles
- No layout or functionality changes introduced
- Added screenshots demonstrating improved dark mode readability
<img width="1920" height="1140" alt="Screenshot 2026-05-08 194813" src="https://github.com/user-attachments/assets/34708478-02a9-4dd3-a31a-31776178f746" />
