### PR TITLE
surface JSON/protocol errors in MCP child-process stdout parsing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+- [ ] Add idempotency guard to Razorpay webhook invoice generation (processPaymentInvoice) using a durable marker keyed by payment_id.
+- [ ] Make fallback invoice number deterministic (no Math.random()) so repeated processing yields the same invoice_number.
+- [ ] Return “already processed” when duplicate webhook arrives.
+- [ ] Add/adjust a simple regression test or manual test flow for duplicate webhook delivery.
+

--- a/flowconnect/airtable-mcp/sendAirtable.js
+++ b/flowconnect/airtable-mcp/sendAirtable.js
@@ -44,7 +44,14 @@ function callAirtable(toolName, args) {
               resolve(JSON.parse(msg.result.content[0].text));
             }
           }
-        } catch (e) {}
+        } catch (e) {
+          // Avoid swallowing protocol/JSON parsing errors silently.
+          // Keep the flow moving, but surface the root cause.
+          child.kill();
+          done = true;
+          reject(e instanceof Error ? e : new Error(String(e)));
+          break;
+        }
       }
     });
 

--- a/flowconnect/slack-mcp/sendSlack.js
+++ b/flowconnect/slack-mcp/sendSlack.js
@@ -44,7 +44,14 @@ function callSlack(toolName, args) {
               resolve(JSON.parse(msg.result.content[0].text));
             }
           }
-        } catch (e) {}
+        } catch (e) {
+          // Avoid swallowing protocol/JSON parsing errors silently.
+          // Keep the flow moving, but surface the root cause.
+          child.kill();
+          done = true;
+          reject(e instanceof Error ? e : new Error(String(e)));
+          break;
+        }
       }
     });
 


### PR DESCRIPTION

This pr removes silent failures in the MCP wrapper helpers (e.g., sendAirtable.js, sendSlack.js).

Previously, stdout line parsing was wrapped with an empty `catch (e) {}` which swallowed JSON/protocol parsing problems and made debugging painful (timeouts/generic errors with no root cause).

Now, when parsing fails we:
- terminate the child process
- reject the promise with the actual parsing/protocol error
- break out of the parsing loop

Net effect: real errors are surfaced immediately instead of being hidden.


Author: @goyaljiiiiii
Reference issue: #105 