### PR TITLE
feat: add retry logic and dead-letter queue for failed workflow execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# ── Auth Backend (flowconnect/auth-backend/auth-server.js) ──────────────────
+
+# Port the auth backend listens on (default: 4000; npm run auth:server overrides to 5000)
+AUTH_PORT=4000
+
+# JWT signing secret — change this in production
+JWT_SECRET=dev-secret-change-me
+
+# Override default file paths for local JSON storage (optional)
+# AUTH_USERS_FILE=flowconnect/auth-backend/users.json
+# AUTH_WORKFLOWS_FILE=flowconnect/auth-backend/workflows.local.json
+# AUTH_APPS_FILE=flowconnect/auth-backend/apps.local.json
+# AUTH_LOGS_FILE=flowconnect/auth-backend/execution-logs.local.json
+
+# ── Queue / Retry (optional — requires a running Redis instance) ─────────────
+
+# Redis connection URL. When set, workflow executions run through Bull queues
+# with automatic retry and a dead-letter queue for exhausted jobs.
+# Leave unset to run without a queue (direct synchronous execution).
+REDIS_URL=redis://localhost:6379
+
+# Maximum retry attempts before a job moves to the dead-letter queue (default: 3)
+QUEUE_MAX_RETRIES=3
+
+# Initial backoff delay in milliseconds (default: 2000)
+QUEUE_BACKOFF_DELAY=2000
+
+# Backoff strategy: "exponential" or "fixed" (default: exponential)
+QUEUE_BACKOFF_TYPE=exponential
+
+# ── Google Forms integration ─────────────────────────────────────────────────
+
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+
+# Polling interval for Google Forms responses in milliseconds (default: 60000)
+GOOGLE_FORMS_POLL_MS=60000
+
+# Secret header value checked on incoming Google Forms webhook requests (optional)
+GOOGLE_FORMS_WEBHOOK_SECRET=
+
+# ── Frontend (Vite) ───────────────────────────────────────────────────────────
+
+# Base URL the frontend uses to reach the auth backend (default: http://localhost:4000)
+VITE_AUTH_API_BASE_URL=http://localhost:4000
+
+# ── Production Express server (index.js) ────────────────────────────────────
+
+# Port the production server listens on (default: 3000)
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 *.env
 *.env.*
+!.env.example
 !flowconnect/whatsapp-chatbot-mcp/.env.example
 !flowconnect/notion-mcp/.env.example
 **/*.env

--- a/flowconnect/auth-backend/auth-server.js
+++ b/flowconnect/auth-backend/auth-server.js
@@ -7,6 +7,12 @@ import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 import { randomUUID } from "crypto";
+import {
+  workflowQueue,
+  deadLetterQueue,
+  enqueueWorkflowJob,
+  MAX_RETRIES,
+} from "./queue.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -403,14 +409,14 @@ function isGoogleFormsWorkflow(workflow) {
   return !!getGoogleTriggerConfig(workflow).form_id;
 }
 
-async function markWorkflowRun(workflowId, payload, success = true) {
+async function markWorkflowRun(workflowId, payload, success = true, error = null) {
   const workflows = await readWorkflows();
   const index = workflows.findIndex((workflow) => workflow.id === workflowId);
-  if (index === -1) return;
+  if (index === -1) return null;
 
   const existing = workflows[index];
   const now = new Date().toISOString();
-  
+
   const updated = {
     ...existing,
     run_count: (existing.run_count || 0) + 1,
@@ -424,34 +430,41 @@ async function markWorkflowRun(workflowId, payload, success = true) {
   workflows[index] = updated;
   await writeWorkflows(workflows);
 
-  //Write to Execution Logs
+  const logId = randomUUID();
   const logs = await readLogs();
-  logs.push({
-    id: randomUUID(),
+  const entry = {
+    id: logId,
     workflow_id: workflowId,
     workflow_name: existing.name,
     user_id: existing.user_id,
-    success: success,
-    payload: payload,
-    executed_at: now
-  });
-  
+    success,
+    payload,
+    executed_at: now,
+  };
+  if (error !== null) entry.error = error;
+  logs.push(entry);
+
   // Keep file size manageable by capping at 2000 logs total
   if (logs.length > 2000) {
     logs.shift();
   }
   await writeLogs(logs);
+  return logId;
 }
 
 async function executeGoogleFormsWorkflow(workflow, triggerPayload) {
-  // Action execution adapters are integration-specific and can be layered here.
-  // For now we persist trigger execution metadata and workflow run counters.
-  await markWorkflowRun(workflow.id, {
+  const executionPayload = {
     source: "googleforms",
     trigger: workflow.trigger,
     trigger_payload: triggerPayload,
     actions: workflow.actions || [],
-  });
+  };
+
+  if (workflowQueue) {
+    await enqueueWorkflowJob(workflow.id, executionPayload);
+  } else {
+    await markWorkflowRun(workflow.id, executionPayload);
+  }
 }
 
 async function pollGoogleFormsTriggers() {
@@ -1109,6 +1122,87 @@ app.post("/api/webhooks/googleforms", async (req, res) => {
     triggered_workflows: workflows.length,
   });
 });
+
+app.get("/api/workflows/failed-jobs", authMiddleware, async (req, res) => {
+  if (!deadLetterQueue) return res.json([]);
+  try {
+    const jobs = await deadLetterQueue.getJobs(["waiting", "delayed", "active"]);
+    const workflows = await readWorkflows();
+    const userWorkflowIds = new Set(
+      workflows.filter((w) => w.user_id === req.user.id).map((w) => w.id)
+    );
+    return res.json(
+      jobs
+        .filter((j) => userWorkflowIds.has(j.data.workflowId))
+        .map((j) => ({
+          jobId: j.id,
+          workflowId: j.data.workflowId,
+          executionPayload: j.data.executionPayload,
+        }))
+    );
+  } catch (err) {
+    return res.status(500).json({ detail: String(err.message) });
+  }
+});
+
+app.post("/api/workflows/retry/:logId", authMiddleware, async (req, res) => {
+  if (!deadLetterQueue) {
+    return res.status(503).json({ detail: "Queue not enabled. Set REDIS_URL to enable retry." });
+  }
+  try {
+    const job = await deadLetterQueue.getJob(req.params.logId);
+    if (!job) {
+      return res.status(404).json({ detail: "Job not found in dead-letter queue." });
+    }
+    const workflows = await readWorkflows();
+    const workflow = workflows.find(
+      (w) => w.id === job.data.workflowId && w.user_id === req.user.id
+    );
+    if (!workflow) {
+      return res.status(403).json({ detail: "Not authorized or workflow not found." });
+    }
+    await job.remove();
+    await enqueueWorkflowJob(job.data.workflowId, job.data.executionPayload);
+    return res.json({ ok: true, message: "Job requeued for retry." });
+  } catch (err) {
+    return res.status(500).json({ detail: String(err.message) });
+  }
+});
+
+if (workflowQueue) {
+  workflowQueue.process(async (job) => {
+    const { workflowId, executionPayload } = job.data;
+    const workflows = await readWorkflows();
+    const workflow = workflows.find((w) => w.id === workflowId);
+    if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+    await markWorkflowRun(workflow.id, executionPayload, true);
+  });
+
+  workflowQueue.on("failed", async (job, err) => {
+    const maxAttempts = job.opts.attempts || MAX_RETRIES;
+    if (job.attemptsMade < maxAttempts) return;
+    try {
+      const logId = await markWorkflowRun(
+        job.data.workflowId,
+        job.data.executionPayload,
+        false,
+        err.message
+      );
+      if (logId) {
+        await deadLetterQueue.add(
+          { workflowId: job.data.workflowId, executionPayload: job.data.executionPayload },
+          { jobId: logId }
+        );
+      }
+    } catch (e) {
+      console.error("[Queue] Failed to record failed job:", e.message);
+    }
+  });
+
+  console.log("[Queue] Workflow queue initialized with Redis");
+} else {
+  console.log("[Queue] REDIS_URL not set — running without queue (direct execution)");
+}
 
 setInterval(() => {
   pollGoogleFormsTriggers().catch((error) => {

--- a/flowconnect/auth-backend/queue.js
+++ b/flowconnect/auth-backend/queue.js
@@ -1,0 +1,35 @@
+import Bull from "bull";
+
+export const MAX_RETRIES = Number(process.env.QUEUE_MAX_RETRIES || 3);
+export const BACKOFF_DELAY = Number(process.env.QUEUE_BACKOFF_DELAY || 2000);
+export const BACKOFF_TYPE = process.env.QUEUE_BACKOFF_TYPE || "exponential";
+
+const REDIS_URL = process.env.REDIS_URL;
+
+export let workflowQueue = null;
+export let deadLetterQueue = null;
+
+if (REDIS_URL) {
+  const opts = { redis: REDIS_URL };
+  workflowQueue = new Bull("workflow-execution", opts);
+  deadLetterQueue = new Bull("workflow-dlq", opts);
+
+  workflowQueue.on("error", (err) => {
+    console.error("[Queue] Workflow queue error:", err.message);
+  });
+  deadLetterQueue.on("error", (err) => {
+    console.error("[Queue] DLQ error:", err.message);
+  });
+}
+
+export async function enqueueWorkflowJob(workflowId, executionPayload) {
+  if (!workflowQueue) return null;
+  return workflowQueue.add(
+    { workflowId, executionPayload },
+    {
+      attempts: MAX_RETRIES,
+      backoff: { type: BACKOFF_TYPE, delay: BACKOFF_DELAY },
+      removeOnComplete: true,
+    }
+  );
+}

--- a/src/api/runHistory.ts
+++ b/src/api/runHistory.ts
@@ -3,26 +3,35 @@ export interface ExecutionLog {
   workflow_id: string;
   workflow_name: string;
   success: boolean;
+  error?: string;
   payload: any;
   executed_at: string;
 }
 
 const AUTH_BASE = import.meta.env.VITE_AUTH_API_BASE_URL || "http://localhost:4000";
 
+function authHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+  };
+}
+
 export async function getRunHistory(): Promise<ExecutionLog[]> {
-  const token = localStorage.getItem("access_token");
-  
   const res = await fetch(`${AUTH_BASE}/api/run-history`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${token}`
-    }
+    headers: authHeaders(),
   });
-
-  if (!res.ok) {
-    throw new Error(`HTTP Error: ${res.status}`);
-  }
-
+  if (!res.ok) throw new Error(`HTTP Error: ${res.status}`);
   return res.json();
+}
+
+export async function retryJob(logId: string): Promise<void> {
+  const res = await fetch(`${AUTH_BASE}/api/workflows/retry/${logId}`, {
+    method: "POST",
+    headers: authHeaders(),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.detail || `HTTP Error: ${res.status}`);
+  }
 }

--- a/src/pages/RunHistoryPage.tsx
+++ b/src/pages/RunHistoryPage.tsx
@@ -1,10 +1,29 @@
 import React, { useEffect, useState } from "react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
-import { getRunHistory, type ExecutionLog } from "../api/runHistory";
+import { getRunHistory, retryJob, type ExecutionLog } from "../api/runHistory";
 
 export default function RunHistoryPage() {
   const [logs, setLogs] = useState<ExecutionLog[]>([]);
   const [loading, setLoading] = useState(true);
+  const [retrying, setRetrying] = useState<Set<string>>(new Set());
+
+  async function handleRetry(logId: string) {
+    setRetrying((prev) => new Set(prev).add(logId));
+    try {
+      await retryJob(logId);
+      setLogs((prev) =>
+        prev.map((l) => (l.id === logId ? { ...l, success: true, error: undefined } : l))
+      );
+    } catch (err: any) {
+      alert(err.message || "Retry failed");
+    } finally {
+      setRetrying((prev) => {
+        const next = new Set(prev);
+        next.delete(logId);
+        return next;
+      });
+    }
+  }
 
   useEffect(() => {
     async function fetchLogs() {
@@ -89,6 +108,7 @@ export default function RunHistoryPage() {
                   <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Workflow Name</th>
                   <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Status</th>
                   <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Payload / Error</th>
+                  <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Actions</th>
                 </tr>
               </thead>
               <tbody style={{ fontSize: 14, color: "#374151" }}>
@@ -100,10 +120,10 @@ export default function RunHistoryPage() {
                       </td>
                       <td style={{ padding: "16px 24px", fontWeight: 500 }}>{log.workflow_name}</td>
                       <td style={{ padding: "16px 24px" }}>
-                        <span style={{ 
-                          padding: "4px 10px", 
-                          borderRadius: 20, 
-                          fontSize: 12, 
+                        <span style={{
+                          padding: "4px 10px",
+                          borderRadius: 20,
+                          fontSize: 12,
                           fontWeight: 600,
                           background: log.success ? "#dcfce7" : "#fee2e2",
                           color: log.success ? "#166534" : "#991b1b"
@@ -112,25 +132,45 @@ export default function RunHistoryPage() {
                         </span>
                       </td>
                       <td style={{ padding: "16px 24px", maxWidth: 300 }}>
-                        <div style={{ 
-                          background: "#f9fafb", 
-                          padding: 8, 
-                          borderRadius: 6, 
-                          fontSize: 11, 
-                          fontFamily: "monospace", 
-                          color: "#6b7280",
+                        <div style={{
+                          background: log.success ? "#f9fafb" : "#fff5f5",
+                          padding: 8,
+                          borderRadius: 6,
+                          fontSize: 11,
+                          fontFamily: "monospace",
+                          color: log.success ? "#6b7280" : "#991b1b",
                           whiteSpace: "nowrap",
                           overflow: "hidden",
                           textOverflow: "ellipsis"
                         }}>
-                          {JSON.stringify(log.payload)}
+                          {!log.success && log.error ? log.error : JSON.stringify(log.payload)}
                         </div>
+                      </td>
+                      <td style={{ padding: "16px 24px" }}>
+                        {!log.success && (
+                          <button
+                            onClick={() => handleRetry(log.id)}
+                            disabled={retrying.has(log.id)}
+                            style={{
+                              padding: "4px 12px",
+                              borderRadius: 6,
+                              fontSize: 12,
+                              fontWeight: 600,
+                              border: "1px solid #d1d5db",
+                              background: retrying.has(log.id) ? "#f3f4f6" : "#fff",
+                              color: retrying.has(log.id) ? "#9ca3af" : "#374151",
+                              cursor: retrying.has(log.id) ? "not-allowed" : "pointer",
+                            }}
+                          >
+                            {retrying.has(log.id) ? "Retrying…" : "Retry"}
+                          </button>
+                        )}
                       </td>
                     </tr>
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={4} style={{ padding: 32, textAlign: "center", color: "#9ca3af" }}>
+                    <td colSpan={5} style={{ padding: 32, textAlign: "center", color: "#9ca3af" }}>
                       No executions recorded yet.
                     </td>
                   </tr>


### PR DESCRIPTION
Closes #114

## Summary

Adds retry logic and a dead-letter queue (DLQ) for failed workflow executions using the existing `bull` dependency. A new `queue.js` module sets up a `workflowQueue` (with configurable attempts and exponential backoff) and a `deadLetterQueue`. Both are only initialized when `REDIS_URL` is set — without it the server falls back to direct synchronous execution, so existing local dev setups are unaffected. After all retries are exhausted, the failed job is logged to `execution-logs.local.json` with an `error` field and moved to the DLQ. Two new auth-guarded endpoints are added: `GET /api/workflows/failed-jobs` and `POST /api/workflows/retry/:logId`. The Run History page now shows the error message in red for failed rows and a per-row Retry button.

## Testing

- [ ] `npm run lint`
- [ ] `npm run build`

## Notes

- Requires a running Redis instance and `REDIS_URL` set in `.env` to activate queue behaviour. A `.env.example` is included documenting all new variables (`REDIS_URL`, `QUEUE_MAX_RETRIES`, `QUEUE_BACKOFF_DELAY`, `QUEUE_BACKOFF_TYPE`).
- Without `REDIS_URL`, everything works exactly as before — no Redis needed for local dev.
- The Bull job ID in the DLQ is set to the execution log UUID, so the retry endpoint takes a log ID directly (no extra field needed in the frontend).
