### PR TITLE
feat: expose integrations as unified MCP tool server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,30 @@
+# ── Unified MCP Server (npm run mcp:server) ──────────────────────────────────
+# All integration sections below are optional — the server skips any service
+# whose credentials are not set and logs a warning on startup.
+
+# Slack
+SLACK_WEBHOOK_URL=
+
+# Discord
+DISCORD_WEBHOOK_URL=
+
+# Telegram
+TELEGRAM_BOT_TOKEN=
+
+# Razorpay
+RAZORPAY_KEY_ID=
+RAZORPAY_KEY_SECRET=
+
+# Airtable
+AIRTABLE_API_KEY=
+AIRTABLE_BASE_ID=
+AIRTABLE_TABLE_NAME=Payments
+
+# Zoho CRM
+ZOHO_CLIENT_ID=
+ZOHO_CLIENT_SECRET=
+ZOHO_REFRESH_TOKEN=
+
 # ── Auth Backend (flowconnect/auth-backend/auth-server.js) ──────────────────
 
 # Port the auth backend listens on (default: 4000; npm run auth:server overrides to 5000)

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# ── Auth Backend (flowconnect/auth-backend/auth-server.js) ──────────────────
+
+# Port the auth backend listens on (default: 4000; npm run auth:server overrides to 5000)
+AUTH_PORT=4000
+
+# JWT signing secret — change this in production
+JWT_SECRET=dev-secret-change-me
+
+# Override default file paths for local JSON storage (optional)
+# AUTH_USERS_FILE=flowconnect/auth-backend/users.json
+# AUTH_WORKFLOWS_FILE=flowconnect/auth-backend/workflows.local.json
+# AUTH_APPS_FILE=flowconnect/auth-backend/apps.local.json
+# AUTH_LOGS_FILE=flowconnect/auth-backend/execution-logs.local.json
+
+# ── Queue / Retry (optional — requires a running Redis instance) ─────────────
+
+# Redis connection URL. When set, workflow executions run through Bull queues
+# with automatic retry and a dead-letter queue for exhausted jobs.
+# Leave unset to run without a queue (direct synchronous execution).
+REDIS_URL=redis://localhost:6379
+
+# Maximum retry attempts before a job moves to the dead-letter queue (default: 3)
+QUEUE_MAX_RETRIES=3
+
+# Initial backoff delay in milliseconds (default: 2000)
+QUEUE_BACKOFF_DELAY=2000
+
+# Backoff strategy: "exponential" or "fixed" (default: exponential)
+QUEUE_BACKOFF_TYPE=exponential
+
+# ── Google Forms integration ─────────────────────────────────────────────────
+
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+
+# Polling interval for Google Forms responses in milliseconds (default: 60000)
+GOOGLE_FORMS_POLL_MS=60000
+
+# Secret header value checked on incoming Google Forms webhook requests (optional)
+GOOGLE_FORMS_WEBHOOK_SECRET=
+
+# ── Frontend (Vite) ───────────────────────────────────────────────────────────
+
+# Base URL the frontend uses to reach the auth backend (default: http://localhost:4000)
+VITE_AUTH_API_BASE_URL=http://localhost:4000
+
+# ── Production Express server (index.js) ────────────────────────────────────
+
+# Port the production server listens on (default: 3000)
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 *.env
 *.env.*
+!.env.example
 !flowconnect/whatsapp-chatbot-mcp/.env.example
 !flowconnect/notion-mcp/.env.example
 **/*.env

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Command	Description
 
 npm run dev	Start frontend (Vite)
 npm run auth:server	Start local auth backend
+npm run mcp:server	Start MCP tool server for AI agents
 npm run server	Start Express server (nodemon)
 npm run build	Build frontend
 npm run lint	Run ESLint
@@ -178,6 +179,48 @@ Accounting → Tally
 
 Each module is independently extendable.
 
+
+---
+
+## 🤖 MCP Server (AI Agent Tools)
+
+Pravah exposes all integrations as [Model Context Protocol](https://modelcontextprotocol.io) tools, allowing AI agents (Claude Desktop, Cursor, etc.) to trigger Pravah workflows directly.
+
+**Start the server:**
+```bash
+npm run mcp:server
+```
+
+**29 tools across 6 services:**
+
+| Service | Tools |
+|---|---|
+| Slack | `slack_send_message`, `slack_send_payment_alert`, `slack_send_notification`, `slack_send_block` |
+| Discord | `discord_send_message`, `discord_send_payment_alert`, `discord_send_embed`, `discord_send_notification` |
+| Telegram | `telegram_send_message`, `telegram_send_payment_alert`, `telegram_get_bot_info`, `telegram_get_updates` |
+| Razorpay | `razorpay_get_todays_payments`, `razorpay_get_payments_by_range`, `razorpay_get_payment_details`, `razorpay_get_payment_summary` |
+| Airtable | `airtable_add_payment`, `airtable_get_payments`, `airtable_add_record`, `airtable_get_records`, `airtable_update_record`, `airtable_search_records` |
+| Zoho CRM | `zoho_create_lead`, `zoho_create_contact`, `zoho_create_deal`, `zoho_create_task`, `zoho_get_leads`, `zoho_search_leads`, `zoho_update_lead` |
+
+Tools for services without credentials set are automatically skipped at startup.
+
+**Connect to Claude Desktop** (`claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "pravah": {
+      "command": "node",
+      "args": ["/absolute/path/to/flowconnect/flowconnect/mcp/server.js"],
+      "env": {
+        "SLACK_WEBHOOK_URL": "your_slack_webhook",
+        "RAZORPAY_KEY_ID": "your_key_id"
+      }
+    }
+  }
+}
+```
+
+See `.env.example` for all available environment variables.
 
 ---
 

--- a/flowconnect/auth-backend/auth-server.js
+++ b/flowconnect/auth-backend/auth-server.js
@@ -7,6 +7,12 @@ import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 import { randomUUID } from "crypto";
+import {
+  workflowQueue,
+  deadLetterQueue,
+  enqueueWorkflowJob,
+  MAX_RETRIES,
+} from "./queue.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -403,14 +409,14 @@ function isGoogleFormsWorkflow(workflow) {
   return !!getGoogleTriggerConfig(workflow).form_id;
 }
 
-async function markWorkflowRun(workflowId, payload, success = true) {
+async function markWorkflowRun(workflowId, payload, success = true, error = null) {
   const workflows = await readWorkflows();
   const index = workflows.findIndex((workflow) => workflow.id === workflowId);
-  if (index === -1) return;
+  if (index === -1) return null;
 
   const existing = workflows[index];
   const now = new Date().toISOString();
-  
+
   const updated = {
     ...existing,
     run_count: (existing.run_count || 0) + 1,
@@ -424,34 +430,41 @@ async function markWorkflowRun(workflowId, payload, success = true) {
   workflows[index] = updated;
   await writeWorkflows(workflows);
 
-  //Write to Execution Logs
+  const logId = randomUUID();
   const logs = await readLogs();
-  logs.push({
-    id: randomUUID(),
+  const entry = {
+    id: logId,
     workflow_id: workflowId,
     workflow_name: existing.name,
     user_id: existing.user_id,
-    success: success,
-    payload: payload,
-    executed_at: now
-  });
-  
+    success,
+    payload,
+    executed_at: now,
+  };
+  if (error !== null) entry.error = error;
+  logs.push(entry);
+
   // Keep file size manageable by capping at 2000 logs total
   if (logs.length > 2000) {
     logs.shift();
   }
   await writeLogs(logs);
+  return logId;
 }
 
 async function executeGoogleFormsWorkflow(workflow, triggerPayload) {
-  // Action execution adapters are integration-specific and can be layered here.
-  // For now we persist trigger execution metadata and workflow run counters.
-  await markWorkflowRun(workflow.id, {
+  const executionPayload = {
     source: "googleforms",
     trigger: workflow.trigger,
     trigger_payload: triggerPayload,
     actions: workflow.actions || [],
-  });
+  };
+
+  if (workflowQueue) {
+    await enqueueWorkflowJob(workflow.id, executionPayload);
+  } else {
+    await markWorkflowRun(workflow.id, executionPayload);
+  }
 }
 
 async function pollGoogleFormsTriggers() {
@@ -1109,6 +1122,87 @@ app.post("/api/webhooks/googleforms", async (req, res) => {
     triggered_workflows: workflows.length,
   });
 });
+
+app.get("/api/workflows/failed-jobs", authMiddleware, async (req, res) => {
+  if (!deadLetterQueue) return res.json([]);
+  try {
+    const jobs = await deadLetterQueue.getJobs(["waiting", "delayed", "active"]);
+    const workflows = await readWorkflows();
+    const userWorkflowIds = new Set(
+      workflows.filter((w) => w.user_id === req.user.id).map((w) => w.id)
+    );
+    return res.json(
+      jobs
+        .filter((j) => userWorkflowIds.has(j.data.workflowId))
+        .map((j) => ({
+          jobId: j.id,
+          workflowId: j.data.workflowId,
+          executionPayload: j.data.executionPayload,
+        }))
+    );
+  } catch (err) {
+    return res.status(500).json({ detail: String(err.message) });
+  }
+});
+
+app.post("/api/workflows/retry/:logId", authMiddleware, async (req, res) => {
+  if (!deadLetterQueue) {
+    return res.status(503).json({ detail: "Queue not enabled. Set REDIS_URL to enable retry." });
+  }
+  try {
+    const job = await deadLetterQueue.getJob(req.params.logId);
+    if (!job) {
+      return res.status(404).json({ detail: "Job not found in dead-letter queue." });
+    }
+    const workflows = await readWorkflows();
+    const workflow = workflows.find(
+      (w) => w.id === job.data.workflowId && w.user_id === req.user.id
+    );
+    if (!workflow) {
+      return res.status(403).json({ detail: "Not authorized or workflow not found." });
+    }
+    await job.remove();
+    await enqueueWorkflowJob(job.data.workflowId, job.data.executionPayload);
+    return res.json({ ok: true, message: "Job requeued for retry." });
+  } catch (err) {
+    return res.status(500).json({ detail: String(err.message) });
+  }
+});
+
+if (workflowQueue) {
+  workflowQueue.process(async (job) => {
+    const { workflowId, executionPayload } = job.data;
+    const workflows = await readWorkflows();
+    const workflow = workflows.find((w) => w.id === workflowId);
+    if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+    await markWorkflowRun(workflow.id, executionPayload, true);
+  });
+
+  workflowQueue.on("failed", async (job, err) => {
+    const maxAttempts = job.opts.attempts || MAX_RETRIES;
+    if (job.attemptsMade < maxAttempts) return;
+    try {
+      const logId = await markWorkflowRun(
+        job.data.workflowId,
+        job.data.executionPayload,
+        false,
+        err.message
+      );
+      if (logId) {
+        await deadLetterQueue.add(
+          { workflowId: job.data.workflowId, executionPayload: job.data.executionPayload },
+          { jobId: logId }
+        );
+      }
+    } catch (e) {
+      console.error("[Queue] Failed to record failed job:", e.message);
+    }
+  });
+
+  console.log("[Queue] Workflow queue initialized with Redis");
+} else {
+  console.log("[Queue] REDIS_URL not set — running without queue (direct execution)");
+}
 
 setInterval(() => {
   pollGoogleFormsTriggers().catch((error) => {

--- a/flowconnect/auth-backend/queue.js
+++ b/flowconnect/auth-backend/queue.js
@@ -1,0 +1,35 @@
+import Bull from "bull";
+
+export const MAX_RETRIES = Number(process.env.QUEUE_MAX_RETRIES || 3);
+export const BACKOFF_DELAY = Number(process.env.QUEUE_BACKOFF_DELAY || 2000);
+export const BACKOFF_TYPE = process.env.QUEUE_BACKOFF_TYPE || "exponential";
+
+const REDIS_URL = process.env.REDIS_URL;
+
+export let workflowQueue = null;
+export let deadLetterQueue = null;
+
+if (REDIS_URL) {
+  const opts = { redis: REDIS_URL };
+  workflowQueue = new Bull("workflow-execution", opts);
+  deadLetterQueue = new Bull("workflow-dlq", opts);
+
+  workflowQueue.on("error", (err) => {
+    console.error("[Queue] Workflow queue error:", err.message);
+  });
+  deadLetterQueue.on("error", (err) => {
+    console.error("[Queue] DLQ error:", err.message);
+  });
+}
+
+export async function enqueueWorkflowJob(workflowId, executionPayload) {
+  if (!workflowQueue) return null;
+  return workflowQueue.add(
+    { workflowId, executionPayload },
+    {
+      attempts: MAX_RETRIES,
+      backoff: { type: BACKOFF_TYPE, delay: BACKOFF_DELAY },
+      removeOnComplete: true,
+    }
+  );
+}

--- a/flowconnect/mcp/server.js
+++ b/flowconnect/mcp/server.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import "dotenv/config";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+import { register as registerSlack } from "./tools/slack.tool.js";
+import { register as registerDiscord } from "./tools/discord.tool.js";
+import { register as registerTelegram } from "./tools/telegram.tool.js";
+import { register as registerRazorpay } from "./tools/razorpay.tool.js";
+import { register as registerAirtable } from "./tools/airtable.tool.js";
+import { register as registerZoho } from "./tools/zoho.tool.js";
+
+const server = new McpServer({
+  name: "pravah-mcp",
+  version: "1.0.0",
+});
+
+const total = [
+  registerSlack(server, z),
+  registerDiscord(server, z),
+  registerTelegram(server, z),
+  registerRazorpay(server, z),
+  registerAirtable(server, z),
+  registerZoho(server, z),
+].reduce((a, b) => a + b, 0);
+
+process.stderr.write(`Pravah MCP server started — ${total} tool(s) registered\n`);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/flowconnect/mcp/tools/airtable.tool.js
+++ b/flowconnect/mcp/tools/airtable.tool.js
@@ -1,0 +1,131 @@
+export function register(server, z) {
+  const apiKey = process.env.AIRTABLE_API_KEY;
+  const baseId = process.env.AIRTABLE_BASE_ID;
+  if (!apiKey || !baseId) {
+    process.stderr.write("[airtable] AIRTABLE_API_KEY / AIRTABLE_BASE_ID not set — tools skipped\n");
+    return 0;
+  }
+
+  const TABLE = process.env.AIRTABLE_TABLE_NAME || "Payments";
+  const BASE_URL = `https://api.airtable.com/v0/${baseId}`;
+
+  async function req(method, endpoint, body = null) {
+    const opts = {
+      method,
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    };
+    if (body) opts.body = JSON.stringify(body);
+    const r = await fetch(`${BASE_URL}/${endpoint}`, opts);
+    const data = await r.json();
+    if (!r.ok) throw new Error(`Airtable error: ${data.error?.message || JSON.stringify(data)}`);
+    return data;
+  }
+
+  function ok(data) {
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  server.tool(
+    "airtable_add_payment",
+    "Add a new payment record to Airtable.",
+    {
+      customer_name: z.string().describe("Customer name"),
+      amount: z.number().describe("Payment amount in rupees"),
+      email: z.string().optional().describe("Customer email"),
+      plan: z.string().optional().describe("Plan or product purchased"),
+      payment_id: z.string().optional().describe("Payment/transaction ID"),
+      status: z.string().optional().describe("Payment status: Success, Failed, Pending"),
+      phone: z.string().optional().describe("Customer phone number"),
+    },
+    async ({ customer_name, amount, email, plan, payment_id, status, phone }) => {
+      const now = new Date().toLocaleString("en-IN", { timeZone: "Asia/Kolkata" });
+      const data = await req("POST", encodeURIComponent(TABLE), {
+        records: [{
+          fields: {
+            "Customer Name": customer_name,
+            Amount: amount,
+            Status: status || "Success",
+            "Created At": now,
+            ...(email && { Email: email }),
+            ...(plan && { Plan: plan }),
+            ...(payment_id && { "Payment ID": payment_id }),
+            ...(phone && { Phone: phone }),
+          },
+        }],
+      });
+      return ok({ success: true, record_id: data.records[0].id, message: `Payment record added for ${customer_name} — ₹${amount}` });
+    }
+  );
+
+  server.tool(
+    "airtable_get_payments",
+    "Get payment records from Airtable with optional status filter.",
+    {
+      max_records: z.number().optional().describe("Maximum records to fetch (default 10)"),
+      filter_status: z.string().optional().describe("Filter by status: Success, Failed, Pending"),
+    },
+    async ({ max_records, filter_status }) => {
+      let endpoint = `${encodeURIComponent(TABLE)}?maxRecords=${max_records || 10}`;
+      if (filter_status) endpoint += `&filterByFormula=${encodeURIComponent(`{Status}="${filter_status}"`)}`;
+      const data = await req("GET", endpoint);
+      return ok({ success: true, total: data.records.length, records: data.records.map(r => ({ id: r.id, ...r.fields })) });
+    }
+  );
+
+  server.tool(
+    "airtable_add_record",
+    "Add a custom record to any Airtable table.",
+    {
+      table_name: z.string().describe("Airtable table name"),
+      fields: z.record(z.any()).describe("Key-value pairs of fields to add"),
+    },
+    async ({ table_name, fields }) => {
+      const data = await req("POST", encodeURIComponent(table_name), { records: [{ fields }] });
+      return ok({ success: true, record_id: data.records[0].id, message: `Record added to ${table_name}` });
+    }
+  );
+
+  server.tool(
+    "airtable_get_records",
+    "Get records from any Airtable table.",
+    {
+      table_name: z.string().describe("Airtable table name"),
+      max_records: z.number().optional().describe("Maximum records to fetch (default 10)"),
+    },
+    async ({ table_name, max_records }) => {
+      const data = await req("GET", `${encodeURIComponent(table_name)}?maxRecords=${max_records || 10}`);
+      return ok({ success: true, total: data.records.length, records: data.records.map(r => ({ id: r.id, ...r.fields })) });
+    }
+  );
+
+  server.tool(
+    "airtable_update_record",
+    "Update an existing record in Airtable by record ID.",
+    {
+      table_name: z.string().describe("Airtable table name"),
+      record_id: z.string().describe("Record ID (starts with 'rec')"),
+      fields: z.record(z.any()).describe("Fields to update"),
+    },
+    async ({ table_name, record_id, fields }) => {
+      const data = await req("PATCH", `${encodeURIComponent(table_name)}/${record_id}`, { fields });
+      return ok({ success: true, record_id: data.id, message: `Record ${record_id} updated in ${table_name}` });
+    }
+  );
+
+  server.tool(
+    "airtable_search_records",
+    "Search for records in an Airtable table by field value.",
+    {
+      table_name: z.string().describe("Airtable table name"),
+      field_name: z.string().describe("Field name to search in"),
+      search_value: z.string().describe("Value to search for"),
+    },
+    async ({ table_name, field_name, search_value }) => {
+      const formula = encodeURIComponent(`SEARCH("${search_value}",{${field_name}})`);
+      const data = await req("GET", `${encodeURIComponent(table_name)}?filterByFormula=${formula}`);
+      return ok({ success: true, total: data.records.length, records: data.records.map(r => ({ id: r.id, ...r.fields })) });
+    }
+  );
+
+  return 6;
+}

--- a/flowconnect/mcp/tools/discord.tool.js
+++ b/flowconnect/mcp/tools/discord.tool.js
@@ -1,0 +1,120 @@
+export function register(server, z) {
+  const url = process.env.DISCORD_WEBHOOK_URL;
+  if (!url) {
+    process.stderr.write("[discord] DISCORD_WEBHOOK_URL not set — tools skipped\n");
+    return 0;
+  }
+
+  const AVATAR = "https://cdn-icons-png.flaticon.com/512/2936/2936886.png";
+
+  async function post(payload) {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) throw new Error(`Discord error ${r.status}: ${await r.text()}`);
+  }
+
+  function ok(data) {
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  server.tool(
+    "discord_send_message",
+    "Send a plain-text message to a Discord channel via webhook.",
+    {
+      message: z.string().describe("Message text"),
+      username: z.string().optional().describe("Bot display name override"),
+    },
+    async ({ message, username }) => {
+      await post({ content: message, username: username || "FlowConnect", avatar_url: AVATAR });
+      return ok({ success: true, message: "Message sent to Discord" });
+    }
+  );
+
+  server.tool(
+    "discord_send_payment_alert",
+    "Send a rich embedded payment alert to Discord.",
+    {
+      amount: z.number().describe("Payment amount in rupees"),
+      customer_name: z.string().describe("Customer name"),
+      plan: z.string().optional().describe("Plan or product purchased"),
+      payment_id: z.string().optional().describe("Payment/transaction ID"),
+    },
+    async ({ amount, customer_name, plan, payment_id }) => {
+      const now = new Date().toLocaleString("en-IN", { timeZone: "Asia/Kolkata" });
+      await post({
+        username: "FlowConnect Payments",
+        avatar_url: AVATAR,
+        embeds: [{
+          title: "💰 New Payment Received!",
+          color: 5763719,
+          fields: [
+            { name: "👤 Customer", value: customer_name, inline: true },
+            { name: "💵 Amount", value: `₹${amount}`, inline: true },
+            ...(plan ? [{ name: "📦 Plan", value: plan, inline: true }] : []),
+            ...(payment_id ? [{ name: "🔖 Payment ID", value: `\`${payment_id}\``, inline: false }] : []),
+            { name: "⏰ Time", value: now, inline: false },
+          ],
+          footer: { text: "FlowConnect" },
+          timestamp: new Date().toISOString(),
+        }],
+      });
+      return ok({ success: true, message: `Payment alert sent for ₹${amount} from ${customer_name}` });
+    }
+  );
+
+  server.tool(
+    "discord_send_embed",
+    "Send a rich embedded message to Discord with title, description, color and optional fields.",
+    {
+      title: z.string().describe("Embed title"),
+      description: z.string().describe("Embed body text"),
+      color: z.number().optional().describe("Color as decimal e.g. 5763719 (green), 15548997 (red), 3447003 (blue)"),
+      fields: z.array(z.object({ name: z.string(), value: z.string(), inline: z.boolean().optional() })).optional(),
+    },
+    async ({ title, description, color, fields }) => {
+      await post({
+        username: "FlowConnect",
+        avatar_url: AVATAR,
+        embeds: [{
+          title,
+          description,
+          color: color || 3447003,
+          fields: fields || [],
+          timestamp: new Date().toISOString(),
+          footer: { text: "FlowConnect" },
+        }],
+      });
+      return ok({ success: true, message: "Embed sent to Discord" });
+    }
+  );
+
+  server.tool(
+    "discord_send_notification",
+    "Send a general notification alert to Discord (new signup, form submit, etc.).",
+    {
+      event_type: z.string().describe("Event type e.g. 'New Signup', 'Form Submitted'"),
+      details: z.string().describe("Details about the event"),
+    },
+    async ({ event_type, details }) => {
+      const now = new Date().toLocaleString("en-IN", { timeZone: "Asia/Kolkata" });
+      await post({
+        username: "FlowConnect Alerts",
+        avatar_url: AVATAR,
+        embeds: [{
+          title: `🔔 ${event_type}`,
+          description: details,
+          color: 3447003,
+          fields: [{ name: "⏰ Time", value: now, inline: false }],
+          timestamp: new Date().toISOString(),
+          footer: { text: "FlowConnect" },
+        }],
+      });
+      return ok({ success: true, message: `Notification sent: ${event_type}` });
+    }
+  );
+
+  return 4;
+}

--- a/flowconnect/mcp/tools/razorpay.tool.js
+++ b/flowconnect/mcp/tools/razorpay.tool.js
@@ -1,0 +1,124 @@
+import axios from "axios";
+
+export function register(server, z) {
+  const keyId = process.env.RAZORPAY_KEY_ID;
+  const keySecret = process.env.RAZORPAY_KEY_SECRET;
+  if (!keyId || !keySecret) {
+    process.stderr.write("[razorpay] RAZORPAY_KEY_ID / RAZORPAY_KEY_SECRET not set — tools skipped\n");
+    return 0;
+  }
+
+  const auth = { username: keyId, password: keySecret };
+  const BASE = "https://api.razorpay.com/v1";
+
+  function ok(data) {
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  server.tool(
+    "razorpay_get_todays_payments",
+    "Get all payments received today with total amount.",
+    {},
+    async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const start = now - (now % 86400);
+      const { data } = await axios.get(`${BASE}/payments`, { auth, params: { from: start, to: now, count: 100 } });
+      const payments = data.items || [];
+      const captured = payments.filter(p => p.status === "captured");
+      const total = captured.reduce((s, p) => s + p.amount, 0) / 100;
+      return ok({
+        date: new Date().toLocaleDateString("en-IN"),
+        total_payments: payments.length,
+        captured_payments: captured.length,
+        total_amount: `Rs.${total.toFixed(2)}`,
+        payments: captured.map(p => ({
+          id: p.id,
+          amount: `Rs.${(p.amount / 100).toFixed(2)}`,
+          method: p.method,
+          email: p.email,
+          contact: p.contact,
+          status: p.status,
+          time: new Date(p.created_at * 1000).toLocaleTimeString("en-IN"),
+        })),
+      });
+    }
+  );
+
+  server.tool(
+    "razorpay_get_payments_by_range",
+    "Get payments between two dates.",
+    {
+      from_date: z.string().describe("Start date YYYY-MM-DD"),
+      to_date: z.string().describe("End date YYYY-MM-DD"),
+    },
+    async ({ from_date, to_date }) => {
+      const from = Math.floor(new Date(from_date).getTime() / 1000);
+      const to = Math.floor(new Date(to_date).getTime() / 1000) + 86400;
+      const { data } = await axios.get(`${BASE}/payments`, { auth, params: { from, to, count: 100 } });
+      const payments = data.items || [];
+      const total = payments.reduce((s, p) => s + p.amount, 0) / 100;
+      return ok({
+        from: from_date,
+        to: to_date,
+        total_payments: payments.length,
+        total_amount: `Rs.${total.toFixed(2)}`,
+        payments: payments.map(p => ({
+          id: p.id,
+          amount: `Rs.${(p.amount / 100).toFixed(2)}`,
+          method: p.method,
+          status: p.status,
+          email: p.email,
+          date: new Date(p.created_at * 1000).toLocaleDateString("en-IN"),
+        })),
+      });
+    }
+  );
+
+  server.tool(
+    "razorpay_get_payment_details",
+    "Get details of a specific payment by ID.",
+    { payment_id: z.string().describe("Razorpay payment ID e.g. pay_ABC123") },
+    async ({ payment_id }) => {
+      const { data: p } = await axios.get(`${BASE}/payments/${payment_id}`, { auth });
+      return ok({
+        id: p.id,
+        amount: `Rs.${(p.amount / 100).toFixed(2)}`,
+        currency: p.currency,
+        status: p.status,
+        method: p.method,
+        email: p.email,
+        contact: p.contact,
+        description: p.description,
+        created_at: new Date(p.created_at * 1000).toLocaleString("en-IN"),
+      });
+    }
+  );
+
+  server.tool(
+    "razorpay_get_payment_summary",
+    "Get payment summary — total revenue, success rate, top methods for the past N days.",
+    { days: z.number().describe("Number of past days to analyze e.g. 7, 30") },
+    async ({ days }) => {
+      const now = Math.floor(Date.now() / 1000);
+      const from = now - days * 86400;
+      const { data } = await axios.get(`${BASE}/payments`, { auth, params: { from, to: now, count: 100 } });
+      const payments = data.items || [];
+      const captured = payments.filter(p => p.status === "captured");
+      const failed = payments.filter(p => p.status === "failed");
+      const total = captured.reduce((s, p) => s + p.amount, 0) / 100;
+      const methods = {};
+      captured.forEach(p => { methods[p.method] = (methods[p.method] || 0) + 1; });
+      return ok({
+        period: `Last ${days} days`,
+        total_transactions: payments.length,
+        successful: captured.length,
+        failed: failed.length,
+        success_rate: payments.length ? `${((captured.length / payments.length) * 100).toFixed(1)}%` : "N/A",
+        total_revenue: `Rs.${total.toFixed(2)}`,
+        payment_methods: methods,
+      });
+    }
+  );
+
+  return 4;
+}

--- a/flowconnect/mcp/tools/slack.tool.js
+++ b/flowconnect/mcp/tools/slack.tool.js
@@ -1,0 +1,112 @@
+export function register(server, z) {
+  const url = process.env.SLACK_WEBHOOK_URL;
+  if (!url) {
+    process.stderr.write("[slack] SLACK_WEBHOOK_URL not set — tools skipped\n");
+    return 0;
+  }
+
+  async function post(payload) {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) throw new Error(`Slack error ${r.status}: ${await r.text()}`);
+  }
+
+  function ok(data) {
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  server.tool(
+    "slack_send_message",
+    "Send a plain-text message to a Slack channel via webhook.",
+    { message: z.string().describe("Message text"), emoji: z.string().optional().describe("Bot emoji e.g. ':rocket:'") },
+    async ({ message, emoji }) => {
+      await post({ text: message, icon_emoji: emoji || ":zap:", username: "FlowConnect" });
+      return ok({ success: true, message: "Message sent to Slack" });
+    }
+  );
+
+  server.tool(
+    "slack_send_payment_alert",
+    "Send a rich formatted payment alert to Slack.",
+    {
+      amount: z.number().describe("Payment amount in rupees"),
+      customer_name: z.string().describe("Customer name"),
+      plan: z.string().optional().describe("Plan or product purchased"),
+      payment_id: z.string().optional().describe("Payment/transaction ID"),
+    },
+    async ({ amount, customer_name, plan, payment_id }) => {
+      const now = new Date().toLocaleString("en-IN", { timeZone: "Asia/Kolkata" });
+      await post({
+        username: "FlowConnect Payments",
+        icon_emoji: ":money_with_wings:",
+        attachments: [{
+          color: "good",
+          title: "💰 New Payment Received!",
+          fields: [
+            { title: "👤 Customer", value: customer_name, short: true },
+            { title: "💵 Amount", value: `₹${amount}`, short: true },
+            ...(plan ? [{ title: "📦 Plan", value: plan, short: true }] : []),
+            ...(payment_id ? [{ title: "🔖 Payment ID", value: payment_id, short: true }] : []),
+            { title: "⏰ Time", value: now, short: false },
+          ],
+          footer: "FlowConnect",
+          ts: Math.floor(Date.now() / 1000),
+        }],
+      });
+      return ok({ success: true, message: `Payment alert sent for ₹${amount} from ${customer_name}` });
+    }
+  );
+
+  server.tool(
+    "slack_send_notification",
+    "Send a general notification to Slack (new signup, form submit, new order, etc.).",
+    {
+      event_type: z.string().describe("Event type e.g. 'New Signup', 'Form Submitted'"),
+      details: z.string().describe("Details about the event"),
+      color: z.string().optional().describe("Sidebar color: 'good', 'warning', 'danger', or hex"),
+    },
+    async ({ event_type, details, color }) => {
+      const now = new Date().toLocaleString("en-IN", { timeZone: "Asia/Kolkata" });
+      await post({
+        username: "FlowConnect Alerts",
+        icon_emoji: ":bell:",
+        attachments: [{
+          color: color || "#0099ff",
+          title: `🔔 ${event_type}`,
+          text: details,
+          fields: [{ title: "⏰ Time", value: now, short: false }],
+          footer: "FlowConnect",
+          ts: Math.floor(Date.now() / 1000),
+        }],
+      });
+      return ok({ success: true, message: `Notification sent: ${event_type}` });
+    }
+  );
+
+  server.tool(
+    "slack_send_block",
+    "Send a rich Block Kit message to Slack with a title, body, and optional fields.",
+    {
+      title: z.string().describe("Bold title of the message"),
+      body: z.string().describe("Main body text (supports mrkdwn)"),
+      fields: z.array(z.object({ title: z.string(), value: z.string() })).optional().describe("Optional {title, value} fields shown in two columns"),
+    },
+    async ({ title, body, fields }) => {
+      const blocks = [
+        { type: "header", text: { type: "plain_text", text: title, emoji: true } },
+        { type: "section", text: { type: "mrkdwn", text: body } },
+      ];
+      if (fields?.length) {
+        blocks.push({ type: "section", fields: fields.map(f => ({ type: "mrkdwn", text: `*${f.title}*\n${f.value}` })) });
+      }
+      blocks.push({ type: "divider" });
+      await post({ username: "FlowConnect", icon_emoji: ":zap:", blocks });
+      return ok({ success: true, message: "Block message sent to Slack" });
+    }
+  );
+
+  return 4;
+}

--- a/flowconnect/mcp/tools/telegram.tool.js
+++ b/flowconnect/mcp/tools/telegram.tool.js
@@ -1,0 +1,90 @@
+export function register(server, z) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    process.stderr.write("[telegram] TELEGRAM_BOT_TOKEN not set — tools skipped\n");
+    return 0;
+  }
+
+  const BASE = `https://api.telegram.org/bot${token}`;
+
+  async function call(method, body = {}) {
+    const r = await fetch(`${BASE}/${method}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await r.json();
+    if (!data.ok) throw new Error(`Telegram error: ${data.description}`);
+    return data.result;
+  }
+
+  function ok(data) {
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  server.tool(
+    "telegram_send_message",
+    "Send a text message to a Telegram chat, group, or channel.",
+    {
+      chat_id: z.string().describe("Chat ID or @channel_username. For groups use negative ID like -1001234567890."),
+      message: z.string().describe("Message text (supports Markdown)"),
+      parse_mode: z.enum(["Markdown", "HTML"]).optional().describe("Formatting mode"),
+    },
+    async ({ chat_id, message, parse_mode }) => {
+      const result = await call("sendMessage", { chat_id, text: message, parse_mode: parse_mode || "Markdown" });
+      return ok({ success: true, message_id: result.message_id, chat_id: result.chat.id });
+    }
+  );
+
+  server.tool(
+    "telegram_send_payment_alert",
+    "Send a formatted payment/sales alert to a Telegram chat.",
+    {
+      chat_id: z.string().describe("Chat ID or @channel_username"),
+      amount: z.number().describe("Payment amount in rupees"),
+      customer_name: z.string().describe("Customer name"),
+      plan: z.string().optional().describe("Plan or product purchased"),
+      payment_id: z.string().optional().describe("Payment/transaction ID"),
+    },
+    async ({ chat_id, amount, customer_name, plan, payment_id }) => {
+      const text =
+        `💰 *New Payment Received!*\n\n` +
+        `👤 *Customer:* ${customer_name}\n` +
+        `💵 *Amount:* ₹${amount}\n` +
+        (plan ? `📦 *Plan:* ${plan}\n` : "") +
+        (payment_id ? `🔖 *Payment ID:* \`${payment_id}\`\n` : "") +
+        `⏰ *Time:* ${new Date().toLocaleString("en-IN", { timeZone: "Asia/Kolkata" })}`;
+      const result = await call("sendMessage", { chat_id, text, parse_mode: "Markdown" });
+      return ok({ success: true, message_id: result.message_id });
+    }
+  );
+
+  server.tool(
+    "telegram_get_bot_info",
+    "Get information about the Telegram bot (name, username, ID).",
+    {},
+    async () => {
+      const result = await call("getMe");
+      return ok({ success: true, id: result.id, name: result.first_name, username: `@${result.username}` });
+    }
+  );
+
+  server.tool(
+    "telegram_get_updates",
+    "Get recent messages sent to the bot. Useful for discovering chat IDs.",
+    {},
+    async () => {
+      const result = await call("getUpdates");
+      const chats = result.map(u => ({
+        chat_id: u.message?.chat?.id,
+        chat_type: u.message?.chat?.type,
+        title: u.message?.chat?.title || u.message?.chat?.first_name,
+        from: u.message?.from?.first_name,
+        text: u.message?.text,
+      }));
+      return ok({ success: true, updates_count: result.length, chats });
+    }
+  );
+
+  return 4;
+}

--- a/flowconnect/mcp/tools/zoho.tool.js
+++ b/flowconnect/mcp/tools/zoho.tool.js
@@ -1,0 +1,205 @@
+export function register(server, z) {
+  const clientId = process.env.ZOHO_CLIENT_ID;
+  const clientSecret = process.env.ZOHO_CLIENT_SECRET;
+  const refreshToken = process.env.ZOHO_REFRESH_TOKEN;
+  if (!clientId || !clientSecret || !refreshToken) {
+    process.stderr.write("[zoho] ZOHO_CLIENT_ID / ZOHO_CLIENT_SECRET / ZOHO_REFRESH_TOKEN not set — tools skipped\n");
+    return 0;
+  }
+
+  let accessToken = null;
+  let tokenExpiry = 0;
+
+  async function getToken() {
+    if (accessToken && Date.now() < tokenExpiry) return accessToken;
+    const r = await fetch("https://accounts.zoho.in/oauth/v2/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ refresh_token: refreshToken, client_id: clientId, client_secret: clientSecret, grant_type: "refresh_token" }),
+    });
+    const data = await r.json();
+    if (!data.access_token) throw new Error(`Zoho token error: ${JSON.stringify(data)}`);
+    accessToken = data.access_token;
+    tokenExpiry = Date.now() + (data.expires_in - 60) * 1000;
+    return accessToken;
+  }
+
+  async function api(method, endpoint, body = null) {
+    const token = await getToken();
+    const opts = { method, headers: { Authorization: `Zoho-oauthtoken ${token}`, "Content-Type": "application/json" } };
+    if (body) opts.body = JSON.stringify(body);
+    const r = await fetch(`https://www.zohoapis.in/crm/v2/${endpoint}`, opts);
+    const data = await r.json();
+    if (data.status === "error" || (data.code && data.code !== 0)) throw new Error(`Zoho API error: ${JSON.stringify(data)}`);
+    return data;
+  }
+
+  function ok(data) {
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  server.tool(
+    "zoho_create_lead",
+    "Create a new lead in Zoho CRM after a payment or form submission.",
+    {
+      last_name: z.string().describe("Lead's last name (required by Zoho)"),
+      email: z.string().describe("Lead's email address"),
+      first_name: z.string().optional(),
+      phone: z.string().optional(),
+      company: z.string().optional(),
+      lead_source: z.string().optional().describe("e.g. 'Web', 'Payment', 'Razorpay'"),
+      amount: z.number().optional().describe("Payment amount if from a payment"),
+      description: z.string().optional(),
+    },
+    async (args) => {
+      const data = await api("POST", "Leads", {
+        data: [{
+          Last_Name: args.last_name,
+          Email: args.email,
+          First_Name: args.first_name || "",
+          Phone: args.phone || "",
+          Company: args.company || "",
+          Lead_Source: args.lead_source || "Web",
+          Annual_Revenue: args.amount || 0,
+          Description: args.description || "",
+        }],
+      });
+      const lead = data.data?.[0];
+      return ok({ success: lead?.code === "SUCCESS", lead_id: lead?.details?.id, message: `Lead created for ${args.first_name || ""} ${args.last_name}` });
+    }
+  );
+
+  server.tool(
+    "zoho_create_contact",
+    "Create a new contact in Zoho CRM for a paying customer.",
+    {
+      last_name: z.string().describe("Contact's last name (required)"),
+      email: z.string().describe("Contact's email"),
+      first_name: z.string().optional(),
+      phone: z.string().optional(),
+      account_name: z.string().optional().describe("Company/account name"),
+      description: z.string().optional(),
+    },
+    async (args) => {
+      const data = await api("POST", "Contacts", {
+        data: [{
+          Last_Name: args.last_name,
+          Email: args.email,
+          First_Name: args.first_name || "",
+          Phone: args.phone || "",
+          Account_Name: args.account_name || "",
+          Description: args.description || "",
+        }],
+      });
+      const contact = data.data?.[0];
+      return ok({ success: contact?.code === "SUCCESS", contact_id: contact?.details?.id, message: `Contact created for ${args.first_name || ""} ${args.last_name}` });
+    }
+  );
+
+  server.tool(
+    "zoho_create_deal",
+    "Create a new deal/opportunity in Zoho CRM.",
+    {
+      deal_name: z.string().describe("Name of the deal"),
+      stage: z.string().describe("Deal stage: Qualification, Value Proposition, Closed Won, Closed Lost"),
+      amount: z.number().optional().describe("Deal amount in rupees"),
+      contact_name: z.string().optional(),
+      account_name: z.string().optional(),
+      closing_date: z.string().optional().describe("Expected closing date YYYY-MM-DD"),
+      description: z.string().optional(),
+    },
+    async (args) => {
+      const defaultClose = new Date(Date.now() + 30 * 864e5).toISOString().split("T")[0];
+      const data = await api("POST", "Deals", {
+        data: [{
+          Deal_Name: args.deal_name,
+          Stage: args.stage || "Qualification",
+          Amount: args.amount || 0,
+          Contact_Name: args.contact_name || "",
+          Account_Name: args.account_name || "",
+          Closing_Date: args.closing_date || defaultClose,
+          Description: args.description || "",
+        }],
+      });
+      const deal = data.data?.[0];
+      return ok({ success: deal?.code === "SUCCESS", deal_id: deal?.details?.id, message: `Deal '${args.deal_name}' created` });
+    }
+  );
+
+  server.tool(
+    "zoho_create_task",
+    "Create a follow-up task in Zoho CRM.",
+    {
+      subject: z.string().describe("Task subject/title"),
+      due_date: z.string().optional().describe("Due date YYYY-MM-DD"),
+      status: z.string().optional().describe("Not Started, In Progress, Completed"),
+      priority: z.string().optional().describe("High, Medium, Low"),
+      description: z.string().optional(),
+    },
+    async (args) => {
+      const defaultDue = new Date(Date.now() + 7 * 864e5).toISOString().split("T")[0];
+      const data = await api("POST", "Tasks", {
+        data: [{
+          Subject: args.subject,
+          Due_Date: args.due_date || defaultDue,
+          Status: args.status || "Not Started",
+          Priority: args.priority || "Medium",
+          Description: args.description || "",
+        }],
+      });
+      const task = data.data?.[0];
+      return ok({ success: task?.code === "SUCCESS", task_id: task?.details?.id, message: `Task '${args.subject}' created` });
+    }
+  );
+
+  server.tool(
+    "zoho_get_leads",
+    "Get the most recent leads from Zoho CRM.",
+    { per_page: z.number().optional().describe("Number of leads to fetch (default 10)") },
+    async ({ per_page }) => {
+      const data = await api("GET", `Leads?per_page=${per_page || 10}&sort_by=Created_Time&sort_order=desc`);
+      const leads = (data.data || []).map(l => ({
+        id: l.id,
+        name: `${l.First_Name || ""} ${l.Last_Name}`.trim(),
+        email: l.Email,
+        phone: l.Phone,
+        company: l.Company,
+        source: l.Lead_Source,
+        created: l.Created_Time,
+      }));
+      return ok({ success: true, total: leads.length, leads });
+    }
+  );
+
+  server.tool(
+    "zoho_search_leads",
+    "Search for leads in Zoho CRM by email or name.",
+    {
+      email: z.string().optional().describe("Email to search for"),
+      name: z.string().optional().describe("Name to search for"),
+    },
+    async ({ email, name }) => {
+      const endpoint = email
+        ? `Leads/search?email=${encodeURIComponent(email)}`
+        : `Leads/search?word=${encodeURIComponent(name || "")}`;
+      const data = await api("GET", endpoint);
+      return ok({ success: true, total: data.data?.length || 0, leads: data.data || [] });
+    }
+  );
+
+  server.tool(
+    "zoho_update_lead",
+    "Update an existing lead in Zoho CRM by ID.",
+    {
+      lead_id: z.string().describe("Zoho CRM lead ID"),
+      fields: z.record(z.any()).describe("Fields to update as key-value pairs"),
+    },
+    async ({ lead_id, fields }) => {
+      const data = await api("PUT", `Leads/${lead_id}`, { data: [fields] });
+      const lead = data.data?.[0];
+      return ok({ success: lead?.code === "SUCCESS", lead_id, message: `Lead ${lead_id} updated` });
+    }
+  );
+
+  return 7;
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "auth:server": "node flowconnect/auth-backend/auth-server.js",
+    "mcp:server": "node flowconnect/mcp/server.js",
     "server": "nodemon index.js",
     "start": "node index.js"
   },
@@ -43,7 +44,8 @@
     "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.13.0",
     "reactflow": "^11.11.4",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/api/runHistory.ts
+++ b/src/api/runHistory.ts
@@ -3,26 +3,35 @@ export interface ExecutionLog {
   workflow_id: string;
   workflow_name: string;
   success: boolean;
+  error?: string;
   payload: any;
   executed_at: string;
 }
 
 const AUTH_BASE = import.meta.env.VITE_AUTH_API_BASE_URL || "http://localhost:4000";
 
+function authHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+  };
+}
+
 export async function getRunHistory(): Promise<ExecutionLog[]> {
-  const token = localStorage.getItem("access_token");
-  
   const res = await fetch(`${AUTH_BASE}/api/run-history`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${token}`
-    }
+    headers: authHeaders(),
   });
-
-  if (!res.ok) {
-    throw new Error(`HTTP Error: ${res.status}`);
-  }
-
+  if (!res.ok) throw new Error(`HTTP Error: ${res.status}`);
   return res.json();
+}
+
+export async function retryJob(logId: string): Promise<void> {
+  const res = await fetch(`${AUTH_BASE}/api/workflows/retry/${logId}`, {
+    method: "POST",
+    headers: authHeaders(),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.detail || `HTTP Error: ${res.status}`);
+  }
 }

--- a/src/pages/RunHistoryPage.tsx
+++ b/src/pages/RunHistoryPage.tsx
@@ -1,10 +1,29 @@
 import React, { useEffect, useState } from "react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
-import { getRunHistory, type ExecutionLog } from "../api/runHistory";
+import { getRunHistory, retryJob, type ExecutionLog } from "../api/runHistory";
 
 export default function RunHistoryPage() {
   const [logs, setLogs] = useState<ExecutionLog[]>([]);
   const [loading, setLoading] = useState(true);
+  const [retrying, setRetrying] = useState<Set<string>>(new Set());
+
+  async function handleRetry(logId: string) {
+    setRetrying((prev) => new Set(prev).add(logId));
+    try {
+      await retryJob(logId);
+      setLogs((prev) =>
+        prev.map((l) => (l.id === logId ? { ...l, success: true, error: undefined } : l))
+      );
+    } catch (err: any) {
+      alert(err.message || "Retry failed");
+    } finally {
+      setRetrying((prev) => {
+        const next = new Set(prev);
+        next.delete(logId);
+        return next;
+      });
+    }
+  }
 
   useEffect(() => {
     async function fetchLogs() {
@@ -89,6 +108,7 @@ export default function RunHistoryPage() {
                   <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Workflow Name</th>
                   <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Status</th>
                   <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Payload / Error</th>
+                  <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Actions</th>
                 </tr>
               </thead>
               <tbody style={{ fontSize: 14, color: "#374151" }}>
@@ -100,10 +120,10 @@ export default function RunHistoryPage() {
                       </td>
                       <td style={{ padding: "16px 24px", fontWeight: 500 }}>{log.workflow_name}</td>
                       <td style={{ padding: "16px 24px" }}>
-                        <span style={{ 
-                          padding: "4px 10px", 
-                          borderRadius: 20, 
-                          fontSize: 12, 
+                        <span style={{
+                          padding: "4px 10px",
+                          borderRadius: 20,
+                          fontSize: 12,
                           fontWeight: 600,
                           background: log.success ? "#dcfce7" : "#fee2e2",
                           color: log.success ? "#166534" : "#991b1b"
@@ -112,25 +132,45 @@ export default function RunHistoryPage() {
                         </span>
                       </td>
                       <td style={{ padding: "16px 24px", maxWidth: 300 }}>
-                        <div style={{ 
-                          background: "#f9fafb", 
-                          padding: 8, 
-                          borderRadius: 6, 
-                          fontSize: 11, 
-                          fontFamily: "monospace", 
-                          color: "#6b7280",
+                        <div style={{
+                          background: log.success ? "#f9fafb" : "#fff5f5",
+                          padding: 8,
+                          borderRadius: 6,
+                          fontSize: 11,
+                          fontFamily: "monospace",
+                          color: log.success ? "#6b7280" : "#991b1b",
                           whiteSpace: "nowrap",
                           overflow: "hidden",
                           textOverflow: "ellipsis"
                         }}>
-                          {JSON.stringify(log.payload)}
+                          {!log.success && log.error ? log.error : JSON.stringify(log.payload)}
                         </div>
+                      </td>
+                      <td style={{ padding: "16px 24px" }}>
+                        {!log.success && (
+                          <button
+                            onClick={() => handleRetry(log.id)}
+                            disabled={retrying.has(log.id)}
+                            style={{
+                              padding: "4px 12px",
+                              borderRadius: 6,
+                              fontSize: 12,
+                              fontWeight: 600,
+                              border: "1px solid #d1d5db",
+                              background: retrying.has(log.id) ? "#f3f4f6" : "#fff",
+                              color: retrying.has(log.id) ? "#9ca3af" : "#374151",
+                              cursor: retrying.has(log.id) ? "not-allowed" : "pointer",
+                            }}
+                          >
+                            {retrying.has(log.id) ? "Retrying…" : "Retry"}
+                          </button>
+                        )}
                       </td>
                     </tr>
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={4} style={{ padding: 32, textAlign: "center", color: "#9ca3af" }}>
+                    <td colSpan={5} style={{ padding: 32, textAlign: "center", color: "#9ca3af" }}>
                       No executions recorded yet.
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary

- Add `flowconnect/mcp/server.js` — a unified [Model Context Protocol](https://modelcontextprotocol.io) server that exposes all Pravah integrations as LLM-callable tools
- 29 tools registered across 6 services: Slack (4), Discord (4), Telegram (4), Razorpay (4), Airtable (6), Zoho CRM (7)
- Each tool file gracefully skips registration when its credentials are absent (logs a warning to stderr)
- Add `mcp:server` npm script and `zod` dependency to root `package.json`
- Document all required env vars in `.env.example`
- Add MCP server section and scripts entry to `README.md`

## Testing

- [ ] `npm run lint`
- [ ] `npm run build`

## Notes

- Run `npm install` first to get `zod` and `@modelcontextprotocol/sdk`
- Configure credentials in `.env` (see `.env.example` — only the services you use need keys)
- Start with `npm run mcp:server`; any MCP-compatible client (Claude Desktop, Cursor, etc.) can then call the tools
- The server uses stdio transport — it works as a subprocess tool provider with no HTTP port required
- Tools for unconfigured services are automatically skipped at startup with a stderr warning

Closes #117
