### PR TITLE
Pin Vite dependency to stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "nodemon": "^3.1.10",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^8.0.0-beta.13"
+    "vite": "^7.1.0"
   }
 }


### PR DESCRIPTION
## Summary

Updated the Vite dependency from the unstable beta release (`^8.0.0-beta.13`) to the stable version (`^7.1.0`) in `package.json`.

This improves project stability and avoids issues caused by beta dependencies during development and production builds.

## Testing

* [ ] `npm run lint`
* [ ] `npm run build`

## Notes

This is a dependency stability fix only. No application logic was changed.
