### PR TITLE
fix: dark mode and responsiveness for profile and run history pages

### DIFF
--- a/src/EmptyState.tsx
+++ b/src/EmptyState.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-// This interface fixes the "Implicit Any" errors in TypeScript
 interface EmptyStateProps {
   title?: string;
   desc?: string;
@@ -9,41 +8,53 @@ interface EmptyStateProps {
 
 const EmptyState: React.FC<EmptyStateProps> = ({ title, desc, onAction }) => {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[400px] text-center p-6 transition-all duration-1000">
-      
-      {/* Aesthetic Icon Circle */}
-      <div className="w-20 h-20 mb-6 flex items-center justify-center rounded-full bg-zinc-50 border border-zinc-100 text-zinc-400">
-        <svg 
-          xmlns="http://www.w3.org/2000/svg" 
-          width="32" 
-          height="32" 
-          viewBox="0 0 24 24" 
-          fill="none" 
-          stroke="currentColor" 
-          strokeWidth="1" 
-          strokeLinecap="round" 
-          strokeLinejoin="round"
-        >
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: 360, textAlign: 'center', padding: 24, transition: 'all 0.3s ease' }}>
+
+      <div style={{
+        width: 80, height: 80, marginBottom: 24,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        borderRadius: '50%',
+        background: 'var(--bg-secondary)',
+        border: '1px solid var(--border-default)',
+        color: 'var(--text-muted)',
+      }}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round">
           <rect width="18" height="18" x="3" y="3" rx="2" />
           <path d="M3 9h18" />
           <path d="M9 21V9" />
         </svg>
       </div>
-      
-      <h3 className="text-xl font-light tracking-tight text-zinc-800 mb-2">
-        {title || "No data available"}
+
+      <h3 style={{ fontSize: 20, fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--text-primary)', marginBottom: 8, margin: '0 0 8px' }}>
+        {title || 'No data available'}
       </h3>
-      
-      <p className="text-zinc-500 text-sm max-w-[250px] leading-relaxed font-light">
-        {desc || "There is nothing to show here at the moment."}
+
+      <p style={{ color: 'var(--text-secondary)', fontSize: 14, maxWidth: 250, lineHeight: 1.6, fontWeight: 300, margin: 0 }}>
+        {desc || 'There is nothing to show here at the moment.'}
       </p>
-      
-      <button 
-        onClick={onAction}
-        className="mt-8 px-6 py-2 bg-black text-white rounded-full text-sm hover:opacity-80 transition-all shadow-sm active:scale-95"
-      >
-        Get Started
-      </button>
+
+      {onAction && (
+        <button
+          onClick={onAction}
+          style={{
+            marginTop: 32,
+            padding: '8px 24px',
+            background: 'var(--gradient-primary)',
+            color: 'white',
+            borderRadius: 9999,
+            fontSize: 14,
+            fontWeight: 500,
+            border: 'none',
+            cursor: 'pointer',
+            transition: 'all 0.2s ease',
+          }}
+          onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.opacity = '0.85'; (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(-1px)'; }}
+          onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.opacity = '1'; (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(0)'; }}
+        >
+          Get Started
+        </button>
+      )}
     </div>
   );
 };

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,15 +1,15 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
-import { 
-    User, CreditCard, Shield, Wallet, LogOut, Zap, TrendingUp, Clock, 
-    Plus, Trash2, RefreshCw, Database, FileText, Search, Send, 
-    MessageSquare, AlertCircle, CheckCircle, ExternalLink, BarChart2, 
-    IndianRupee, Repeat, PauseCircle, PlayCircle, XCircle, Bot, Layout 
+import {
+    User, CreditCard, Shield, Wallet, LogOut, Zap, TrendingUp, Clock,
+    Plus, Trash2, RefreshCw, Database, FileText, Search, Send,
+    MessageSquare, AlertCircle, CheckCircle, ExternalLink, BarChart2,
+    IndianRupee, Repeat, PauseCircle, PlayCircle, XCircle, Bot, Layout
 } from 'lucide-react'
 
 import Navbar from '../components/common/Navbar'
 import Footer from '../components/common/Footer'
-import EmptyState from '../EmptyState' 
+import EmptyState from '../EmptyState'
 import { apiCall, logout, getToken } from '../api/client'
 import { getPayments } from '../api/airtable'
 import {
@@ -62,20 +62,6 @@ interface GeneratedInvoice {
     whatsapp_status?: 'sent' | 'failed' | 'skipped'
     email_status?: 'sent' | 'failed' | 'skipped'
     created_at: string
-}
-
-// ── Status color helpers ───────────────────────────────────────────────────────
-const subStatusColor = (status: string) => {
-    switch (status) {
-        case 'active':        return { bg: '#dcfce7', text: '#16a34a' }
-        case 'paused':        return { bg: '#fef3c7', text: '#d97706' }
-        case 'halted':        return { bg: '#fee2e2', text: '#dc2626' }
-        case 'cancelled':     return { bg: '#f3f4f6', text: '#6b7280' }
-        case 'completed':     return { bg: '#eff6ff', text: '#2563eb' }
-        case 'authenticated': return { bg: '#f5f3ff', text: '#7c3aed' }
-        case 'created':       return { bg: '#fef9c3', text: '#ca8a04' }
-        default:              return { bg: '#f3f4f6', text: '#6b7280' }
-    }
 }
 
 export default function ProfilePage() {
@@ -312,9 +298,9 @@ export default function ProfilePage() {
     }
 
     const handleDisconnect = async (appName: string) => {
-        try { 
+        try {
             await apiCall(`/apps/${appName}`, { method: 'DELETE' })
-            setApps(apps.filter(a => a.app_name !== appName)) 
+            setApps(apps.filter(a => a.app_name !== appName))
         } catch {}
     }
 
@@ -367,8 +353,8 @@ export default function ProfilePage() {
     ]
 
     if (loading) return (
-        <div className="profile-page flex items-center justify-center min-h-screen">
-            <div className="animate-pulse text-zinc-400 font-light">Loading profile details...</div>
+        <div className="profile-page" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}>
+            <div style={{ color: 'var(--text-muted)', fontWeight: 300 }}>Loading profile details...</div>
         </div>
     )
 
@@ -391,11 +377,11 @@ export default function ProfilePage() {
                             <button key={id} className={`profile-nav-btn ${activeTab === id ? 'active' : ''}`} onClick={() => setActiveTab(id)}>
                                 <Icon className="profile-nav-icon" />
                                 {label}
-                                {badge && <span className="nav-badge" style={{ background: badge.color, color: '#fff', fontSize: 9, padding: '2px 5px', borderRadius: 4, marginLeft: 'auto' }}>{badge.text}</span>}
+                                {badge && <span className="nav-badge" style={{ background: badge.color }}>{badge.text}</span>}
                             </button>
                         ))}
-                        <div style={{ height: 1, background: '#f3f4f6', margin: '8px 0' }} />
-                        <button className="profile-nav-btn text-red-500" onClick={() => { logout(); window.location.href = '/login' }}>
+                        <div className="profile-nav-separator" />
+                        <button className="profile-nav-btn logout-btn" onClick={() => { logout(); window.location.href = '/login' }}>
                             <LogOut className="profile-nav-icon" /> Log Out
                         </button>
                     </nav>
@@ -407,32 +393,37 @@ export default function ProfilePage() {
                     {activeTab === 'overview' && (
                         <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
                             <h1 className="profile-section-title">Overview</h1>
-                            <div className="profile-stats grid grid-cols-2 gap-4 mb-6">
-                                <div className="stat-card p-6 bg-white border border-zinc-100 rounded-2xl">
-                                    <span className="text-zinc-400 text-sm">Total Workflows</span>
-                                    <div className="text-2xl font-semibold mt-1">{dashboard?.total_workflows || 0}</div>
+                            <div className="profile-stats">
+                                <div className="stat-card">
+                                    <span className="stat-label">Total Workflows</span>
+                                    <div className="stat-value">{dashboard?.total_workflows || 0}</div>
                                 </div>
-                                <div className="stat-card p-6 bg-white border border-zinc-100 rounded-2xl">
-                                    <span className="text-zinc-400 text-sm">Total Executions</span>
-                                    <div className="text-2xl font-semibold mt-1">{dashboard?.total_executions || 0}</div>
+                                <div className="stat-card">
+                                    <span className="stat-label">Total Executions</span>
+                                    <div className="stat-value">{dashboard?.total_executions || 0}</div>
                                 </div>
                             </div>
-                            <div className="profile-card p-8 bg-white border border-zinc-100 rounded-3xl">
-                                <h3 className="text-lg font-medium mb-6">Account Details</h3>
-                                <div className="grid grid-cols-2 gap-6">
-                                    <div className="flex flex-col">
-                                        <span className="text-xs text-zinc-400 uppercase tracking-wider mb-1">Name</span>
-                                        <input className="text-sm font-medium bg-zinc-50 p-2 rounded-lg border-none" value={name} onChange={e => setName(e.target.value)} disabled={!isEditing} />
+                            <div className="profile-card profile-account-card">
+                                <h3 className="profile-account-title">Account Details</h3>
+                                <div className="profile-form-grid">
+                                    <div className="form-group">
+                                        <span className="profile-field-label">Name</span>
+                                        <input
+                                            className="profile-field-input"
+                                            value={name}
+                                            onChange={e => setName(e.target.value)}
+                                            disabled={!isEditing}
+                                        />
                                     </div>
-                                    <div className="flex flex-col">
-                                        <span className="text-xs text-zinc-400 uppercase tracking-wider mb-1">Email</span>
-                                        <div className="text-sm font-medium p-2">{user?.email}</div>
+                                    <div className="form-group">
+                                        <span className="profile-field-label">Email</span>
+                                        <div className="profile-field-value">{user?.email}</div>
                                     </div>
                                 </div>
-                                <button className="mt-8 px-6 py-2 bg-black text-white rounded-full text-xs" onClick={() => isEditing ? handleSave() : setIsEditing(true)}>
+                                <button className="profile-action-btn" onClick={() => isEditing ? handleSave() : setIsEditing(true)}>
                                     {isEditing ? 'Save Changes' : 'Edit Profile'}
                                 </button>
-                                {saveMsg && <p className="text-green-500 text-xs mt-2">{saveMsg}</p>}
+                                {saveMsg && <p className="profile-save-msg">{saveMsg}</p>}
                             </div>
                         </motion.div>
                     )}
@@ -440,27 +431,30 @@ export default function ProfilePage() {
                     {/* ── WORKFLOWS ── */}
                     {activeTab === 'workflows' && (
                         <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
-                            <div className="flex justify-between items-center mb-6">
-                                <h1 className="profile-section-title m-0">My Workflows</h1>
-                                <button className="px-4 py-2 bg-black text-white rounded-full text-xs flex items-center gap-2" onClick={() => window.location.href = '/builder'}>
+                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+                                <h1 className="profile-section-title" style={{ marginBottom: 0 }}>My Workflows</h1>
+                                <button className="profile-new-btn" onClick={() => window.location.href = '/builder'}>
                                     <Plus size={14} /> New Workflow
                                 </button>
                             </div>
                             {workflows.length === 0 ? (
-                                <EmptyState 
-                                    title="Your canvas is empty" 
-                                    desc="Start by creating a simple automation to connect your tools." 
-                                    onAction={() => window.location.href = '/builder'} 
+                                <EmptyState
+                                    title="Your canvas is empty"
+                                    desc="Start by creating a simple automation to connect your tools."
+                                    onAction={() => window.location.href = '/builder'}
                                 />
                             ) : (
-                                <div className="grid gap-4">
+                                <div style={{ display: 'grid', gap: 12 }}>
                                     {workflows.map(wf => (
-                                        <div key={wf.id} className="p-4 border border-zinc-100 rounded-2xl flex justify-between items-center bg-white">
+                                        <div key={wf.id} className="profile-row">
                                             <div>
-                                                <div className="font-medium text-sm">{wf.name}</div>
-                                                <div className="text-xs text-zinc-400 mt-1">Runs: {wf.run_count}</div>
+                                                <div className="profile-row-name">{wf.name}</div>
+                                                <div className="profile-row-meta">Runs: {wf.run_count}</div>
                                             </div>
-                                            <button onClick={() => handleToggleWorkflow(wf.id)} className={`px-4 py-1 rounded-full text-xs ${wf.status === 'active' ? 'bg-green-50 text-green-600' : 'bg-zinc-50 text-zinc-400'}`}>
+                                            <button
+                                                onClick={() => handleToggleWorkflow(wf.id)}
+                                                className={`status-pill ${wf.status === 'active' ? 'status-pill-active' : 'status-pill-paused'}`}
+                                            >
                                                 {wf.status === 'active' ? 'Active' : 'Paused'}
                                             </button>
                                         </div>
@@ -474,7 +468,7 @@ export default function ProfilePage() {
                     {activeTab === 'history' && (
                         <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
                             <h1 className="profile-section-title">Execution History</h1>
-                            <EmptyState 
+                            <EmptyState
                                 title="Quiet for now"
                                 desc="Your execution logs will appear here once your workflows start running."
                             />
@@ -484,21 +478,21 @@ export default function ProfilePage() {
                     {/* ── APPS ── */}
                     {activeTab === 'apps' && (
                         <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
-                            <div className="flex justify-between items-center mb-6">
-                                <h1 className="profile-section-title m-0">Connected Apps</h1>
+                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+                                <h1 className="profile-section-title" style={{ marginBottom: 0 }}>Connected Apps</h1>
                             </div>
                             {apps.length === 0 ? (
-                                <EmptyState 
-                                    title="No apps connected yet" 
-                                    desc="Connect your first tool like Razorpay or Telegram to build automated flows." 
-                                    onAction={() => window.location.href = '/builder'} 
+                                <EmptyState
+                                    title="No apps connected yet"
+                                    desc="Connect your first tool like Razorpay or Telegram to build automated flows."
+                                    onAction={() => window.location.href = '/builder'}
                                 />
                             ) : (
-                                <div className="grid gap-4">
+                                <div style={{ display: 'grid', gap: 12 }}>
                                     {apps.map(app => (
-                                        <div key={app.id} className="p-4 border border-zinc-100 rounded-2xl flex justify-between items-center bg-white">
-                                            <div className="font-medium text-sm">{app.app_name}</div>
-                                            <button onClick={() => handleDisconnect(app.app_name)} className="text-zinc-400 hover:text-red-500">
+                                        <div key={app.id} className="profile-row">
+                                            <div className="profile-row-name">{app.app_name}</div>
+                                            <button onClick={() => handleDisconnect(app.app_name)} className="action-btn">
                                                 <Trash2 size={16} />
                                             </button>
                                         </div>
@@ -515,7 +509,7 @@ export default function ProfilePage() {
                             {payments.length === 0 ? (
                                 <EmptyState title="No payments found" desc="Your processing history from Airtable will appear here." />
                             ) : (
-                                <div className="bg-white border border-zinc-100 rounded-2xl overflow-hidden">
+                                <div className="profile-data-card">
                                     <SkeletonRow count={3} columns={4} />
                                 </div>
                             )}
@@ -527,9 +521,9 @@ export default function ProfilePage() {
                         <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
                             <h1 className="profile-section-title">Razorpay MCP</h1>
                             {rzpToday ? (
-                                <div className="bg-white p-6 border border-zinc-100 rounded-2xl">
-                                    <div className="text-zinc-400 text-xs uppercase mb-2">Today's Revenue</div>
-                                    <div className="text-xl font-bold">{rzpToday.total_amount}</div>
+                                <div className="profile-data-card">
+                                    <div className="profile-data-card-label">Today's Revenue</div>
+                                    <div className="profile-data-card-value">{rzpToday.total_amount}</div>
                                 </div>
                             ) : (
                                 <EmptyState title="No transactions today" desc="Sync your Razorpay account to see real-time revenue stats." />
@@ -544,9 +538,9 @@ export default function ProfilePage() {
                             {!subSummary ? (
                                 <EmptyState title="No active plans" desc="Manage your recurring customer billing through the Razorpay MCP." />
                             ) : (
-                                <div className="stat-card bg-white p-6 rounded-2xl border border-zinc-100">
-                                    <div className="text-sm text-zinc-500">Active Subscriptions</div>
-                                    <div className="text-2xl font-bold">{subSummary.active}</div>
+                                <div className="stat-card">
+                                    <span className="stat-label">Active Subscriptions</span>
+                                    <div className="stat-value">{subSummary.active}</div>
                                 </div>
                             )}
                         </motion.div>
@@ -556,10 +550,10 @@ export default function ProfilePage() {
                     {activeTab === 'telegram' && (
                         <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
                             <h1 className="profile-section-title">Telegram Bot</h1>
-                            <div className="bg-zinc-50 p-8 rounded-3xl border border-zinc-100 text-center">
-                                <Bot size={32} className="mx-auto mb-4 text-zinc-300" />
-                                <h3 className="font-medium">Bot Integration Active</h3>
-                                <p className="text-zinc-500 text-sm mt-2">Use the builder to trigger Telegram alerts for your workflows.</p>
+                            <div className="profile-panel">
+                                <Bot size={32} className="profile-panel-icon" />
+                                <h3 className="profile-panel-title">Bot Integration Active</h3>
+                                <p className="profile-panel-text">Use the builder to trigger Telegram alerts for your workflows.</p>
                             </div>
                         </motion.div>
                     )}
@@ -571,8 +565,12 @@ export default function ProfilePage() {
                             {tfForms.length === 0 ? (
                                 <EmptyState title="No forms found" desc="Connect Typeform to start processing survey responses automatically." />
                             ) : (
-                                <div className="grid gap-2">
-                                    {tfForms.map(f => <div key={f.id} className="p-3 bg-white rounded-xl border border-zinc-100 text-sm">{f.title}</div>)}
+                                <div style={{ display: 'grid', gap: 8 }}>
+                                    {tfForms.map(f => (
+                                        <div key={f.id} className="profile-row">
+                                            <span className="profile-row-name">{f.title}</span>
+                                        </div>
+                                    ))}
                                 </div>
                             )}
                         </motion.div>
@@ -582,9 +580,9 @@ export default function ProfilePage() {
                     {activeTab === 'tally' && (
                         <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
                             <h1 className="profile-section-title">TallyPrime</h1>
-                            <div className="bg-zinc-50 p-8 rounded-3xl border border-zinc-100 text-center">
-                                <Database size={32} className="mx-auto mb-4 text-zinc-300" />
-                                <p className="text-zinc-500 text-sm">Tally ERP integration is live. Syncing ledger data...</p>
+                            <div className="profile-panel">
+                                <Database size={32} className="profile-panel-icon" />
+                                <p className="profile-panel-text">Tally ERP integration is live. Syncing ledger data...</p>
                             </div>
                         </motion.div>
                     )}
@@ -593,8 +591,8 @@ export default function ProfilePage() {
                     {activeTab === 'zoho' && (
                         <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
                             <h1 className="profile-section-title">Zoho CRM</h1>
-                            <div className="p-6 bg-white rounded-2xl border border-zinc-100">
-                                <pre className="text-xs text-zinc-500 font-mono overflow-auto">{JSON.stringify(zohoLeads, null, 2)}</pre>
+                            <div className="profile-data-card">
+                                <pre className="profile-pre">{JSON.stringify(zohoLeads, null, 2)}</pre>
                             </div>
                         </motion.div>
                     )}

--- a/src/pages/RunHistoryPage.tsx
+++ b/src/pages/RunHistoryPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import { getRunHistory, retryJob, type ExecutionLog } from "../api/runHistory";
+import "../styles/RunHistoryPage.css";
 
 export default function RunHistoryPage() {
   const [logs, setLogs] = useState<ExecutionLog[]>([]);
@@ -41,126 +42,92 @@ export default function RunHistoryPage() {
 
   const chartData = React.useMemo(() => {
     const dailyStats: Record<string, { date: string; success: number; failed: number }> = {};
-
     logs.forEach((log) => {
       const date = new Date(log.executed_at).toLocaleDateString();
       if (!dailyStats[date]) dailyStats[date] = { date, success: 0, failed: 0 };
-      
       if (log.success) dailyStats[date].success += 1;
       else dailyStats[date].failed += 1;
     });
-
     return Object.values(dailyStats).reverse();
   }, [logs]);
 
   if (loading) {
-    return (
-      <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100vh", color: "#6b7280" }}>
-        Loading execution history...
-      </div>
-    );
+    return <div className="runhistory-loading">Loading execution history...</div>;
   }
 
   return (
-    <div style={{ backgroundColor: "#f8fafc", minHeight: "100vh", padding: "40px 20px", fontFamily: "'DM Sans', sans-serif" }}>
-      <div style={{ maxWidth: 1000, margin: "0 auto", display: "flex", flexDirection: "column", gap: 24 }}>
-        
+    <div className="runhistory-page">
+      <div className="runhistory-inner">
+
         {/* Header */}
-        <div>
-          <h1 style={{ fontSize: 24, fontWeight: 700, color: "#111827", margin: "0 0 8px 0" }}>Run History</h1>
-          <p style={{ color: "#6b7280", margin: 0, fontSize: 14 }}>View past workflow executions, success rates, and debug payloads.</p>
+        <div className="runhistory-header">
+          <h1>Run History</h1>
+          <p>View past workflow executions, success rates, and debug payloads.</p>
         </div>
 
-        {/* Chart Section */}
-        <div style={{ background: "#fff", padding: 24, borderRadius: 12, border: "1px solid #e5e7eb", boxShadow: "0 2px 8px rgba(0,0,0,0.04)" }}>
-          <h2 style={{ fontSize: 16, fontWeight: 600, color: "#374151", margin: "0 0 20px 0" }}>Execution Trends</h2>
+        {/* Chart */}
+        <div className="runhistory-card">
+          <h2>Execution Trends</h2>
           <div style={{ height: 300, width: "100%" }}>
             {chartData.length > 0 ? (
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
-                  <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 12 }} tickLine={false} axisLine={false} />
-                  <YAxis allowDecimals={false} tick={{ fill: '#6b7280', fontSize: 12 }} tickLine={false} axisLine={false} />
-                  <Tooltip cursor={{ fill: '#f3f4f6' }} contentStyle={{ borderRadius: 8, border: 'none', boxShadow: '0 4px 12px rgba(0,0,0,0.1)' }} />
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border-default)" />
+                  <XAxis dataKey="date" tick={{ fill: 'var(--text-muted)', fontSize: 12 }} tickLine={false} axisLine={false} />
+                  <YAxis allowDecimals={false} tick={{ fill: 'var(--text-muted)', fontSize: 12 }} tickLine={false} axisLine={false} />
+                  <Tooltip
+                    cursor={{ fill: 'var(--bg-hover)' }}
+                    contentStyle={{ borderRadius: 8, border: '1px solid var(--border-default)', background: 'var(--bg-card)', color: 'var(--text-primary)', boxShadow: 'var(--shadow-md)' }}
+                  />
                   <Legend wrapperStyle={{ fontSize: 12, paddingTop: 10 }} />
                   <Bar dataKey="success" name="Successful Runs" fill="#10b981" radius={[4, 4, 0, 0]} barSize={40} />
                   <Bar dataKey="failed" name="Failed Runs" fill="#ef4444" radius={[4, 4, 0, 0]} barSize={40} />
                 </BarChart>
               </ResponsiveContainer>
             ) : (
-              <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: "#9ca3af", fontSize: 14 }}>
-                No data to display yet
-              </div>
+              <div className="runhistory-chart-empty">No data to display yet</div>
             )}
           </div>
         </div>
 
-        {/* Table Section */}
-        <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", boxShadow: "0 2px 8px rgba(0,0,0,0.04)", overflow: "hidden" }}>
-          <div style={{ padding: "16px 24px", borderBottom: "1px solid #e5e7eb" }}>
-            <h2 style={{ fontSize: 16, fontWeight: 600, color: "#374151", margin: 0 }}>Execution Logs</h2>
+        {/* Table */}
+        <div className="runhistory-table-card">
+          <div className="runhistory-table-header">
+            <h2>Execution Logs</h2>
           </div>
-          <div style={{ overflowX: "auto" }}>
-            <table style={{ width: "100%", textAlign: "left", borderCollapse: "collapse" }}>
+          <div className="runhistory-table-scroll">
+            <table className="runhistory-table">
               <thead>
-                <tr style={{ background: "#f9fafb", color: "#6b7280", fontSize: 12, textTransform: "uppercase", letterSpacing: "0.05em" }}>
-                  <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Timestamp</th>
-                  <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Workflow Name</th>
-                  <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Status</th>
-                  <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Payload / Error</th>
-                  <th style={{ padding: "12px 24px", fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>Actions</th>
+                <tr>
+                  <th>Timestamp</th>
+                  <th>Workflow Name</th>
+                  <th>Status</th>
+                  <th>Payload / Error</th>
+                  <th>Actions</th>
                 </tr>
               </thead>
-              <tbody style={{ fontSize: 14, color: "#374151" }}>
+              <tbody>
                 {logs.length > 0 ? (
                   logs.map((log) => (
-                    <tr key={log.id} style={{ borderBottom: "1px solid #f3f4f6" }}>
-                      <td style={{ padding: "16px 24px", whiteSpace: "nowrap", color: "#6b7280" }}>
-                        {new Date(log.executed_at).toLocaleString()}
-                      </td>
-                      <td style={{ padding: "16px 24px", fontWeight: 500 }}>{log.workflow_name}</td>
-                      <td style={{ padding: "16px 24px" }}>
-                        <span style={{
-                          padding: "4px 10px",
-                          borderRadius: 20,
-                          fontSize: 12,
-                          fontWeight: 600,
-                          background: log.success ? "#dcfce7" : "#fee2e2",
-                          color: log.success ? "#166534" : "#991b1b"
-                        }}>
+                    <tr key={log.id}>
+                      <td className="runhistory-ts">{new Date(log.executed_at).toLocaleString()}</td>
+                      <td className="runhistory-workflow">{log.workflow_name}</td>
+                      <td>
+                        <span className={`runhistory-badge ${log.success ? "success" : "failed"}`}>
                           {log.success ? "Success" : "Failed"}
                         </span>
                       </td>
-                      <td style={{ padding: "16px 24px", maxWidth: 300 }}>
-                        <div style={{
-                          background: log.success ? "#f9fafb" : "#fff5f5",
-                          padding: 8,
-                          borderRadius: 6,
-                          fontSize: 11,
-                          fontFamily: "monospace",
-                          color: log.success ? "#6b7280" : "#991b1b",
-                          whiteSpace: "nowrap",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis"
-                        }}>
+                      <td>
+                        <div className={`runhistory-payload${!log.success && log.error ? " error" : ""}`}>
                           {!log.success && log.error ? log.error : JSON.stringify(log.payload)}
                         </div>
                       </td>
-                      <td style={{ padding: "16px 24px" }}>
+                      <td>
                         {!log.success && (
                           <button
                             onClick={() => handleRetry(log.id)}
                             disabled={retrying.has(log.id)}
-                            style={{
-                              padding: "4px 12px",
-                              borderRadius: 6,
-                              fontSize: 12,
-                              fontWeight: 600,
-                              border: "1px solid #d1d5db",
-                              background: retrying.has(log.id) ? "#f3f4f6" : "#fff",
-                              color: retrying.has(log.id) ? "#9ca3af" : "#374151",
-                              cursor: retrying.has(log.id) ? "not-allowed" : "pointer",
-                            }}
+                            className="runhistory-retry"
                           >
                             {retrying.has(log.id) ? "Retrying…" : "Retry"}
                           </button>
@@ -170,9 +137,7 @@ export default function RunHistoryPage() {
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={5} style={{ padding: 32, textAlign: "center", color: "#9ca3af" }}>
-                      No executions recorded yet.
-                    </td>
+                    <td colSpan={5} className="runhistory-empty">No executions recorded yet.</td>
                   </tr>
                 )}
               </tbody>

--- a/src/styles/ProfilePage.css
+++ b/src/styles/ProfilePage.css
@@ -5,13 +5,16 @@
 .profile-page {
     min-height: 100vh;
     padding-top: 100px;
-    /* Space for fixed navbar */
     padding-bottom: 60px;
-    background: linear-gradient(135deg, #fff7ed 0%, var(--bg-card) 100%);
+    background: linear-gradient(135deg, var(--primary-50) 0%, var(--bg-card) 100%);
+}
+
+[data-theme='dark'] .profile-page {
+    background: linear-gradient(135deg, rgba(249, 115, 22, 0.07) 0%, var(--bg-primary) 100%);
 }
 
 .profile-container {
-    max-width: 1024px;
+    max-width: 1100px;
     margin: 0 auto;
     padding: 0 24px;
     display: grid;
@@ -25,7 +28,7 @@
     }
 }
 
-/* Sidebar / User Card */
+/* ── Sidebar ─────────────────────────────── */
 .profile-sidebar {
     display: flex;
     flex-direction: column;
@@ -33,7 +36,7 @@
 }
 
 .profile-card {
-    background: white;
+    background: var(--bg-card);
     border: 1px solid var(--border-default);
     border-radius: 20px;
     padding: 24px;
@@ -43,7 +46,7 @@
 
 .profile-card:hover {
     box-shadow: var(--shadow-md);
-    border-color: var(--primary-200);
+    border-color: var(--border-hover);
 }
 
 .profile-user {
@@ -66,19 +69,21 @@
     font-weight: 700;
     margin-bottom: 16px;
     box-shadow: 0 8px 24px rgba(249, 115, 22, 0.25);
-    border: 4px solid white;
+    border: 4px solid var(--bg-card);
+    flex-shrink: 0;
 }
 
 .profile-name {
     font-size: 20px;
     font-weight: 800;
-    color: var(--gray-900);
+    color: var(--text-primary);
     margin-bottom: 4px;
 }
 
 .profile-email {
     font-size: 14px;
     color: var(--text-secondary);
+    word-break: break-all;
 }
 
 .profile-badge {
@@ -95,7 +100,13 @@
     border: 1px solid var(--primary-100);
 }
 
-/* Navigation Menu */
+[data-theme='dark'] .profile-badge {
+    background: rgba(249, 115, 22, 0.15);
+    color: var(--primary-400);
+    border-color: rgba(249, 115, 22, 0.25);
+}
+
+/* ── Navigation Menu ─────────────────────── */
 .profile-nav {
     display: flex;
     flex-direction: column;
@@ -114,11 +125,13 @@
     transition: all 0.2s ease;
     text-align: left;
     width: 100%;
+    background: transparent;
+    cursor: pointer;
 }
 
 .profile-nav-btn:hover {
-    background: var(--gray-50);
-    color: var(--gray-900);
+    background: var(--bg-hover);
+    color: var(--text-primary);
 }
 
 .profile-nav-btn.active {
@@ -126,44 +139,82 @@
     color: var(--primary-700);
 }
 
+[data-theme='dark'] .profile-nav-btn.active {
+    background: rgba(249, 115, 22, 0.15);
+    color: var(--primary-400);
+}
+
+.profile-nav-btn.logout-btn {
+    color: #ef4444;
+}
+
+.profile-nav-btn.logout-btn:hover {
+    background: rgba(239, 68, 68, 0.08);
+    color: #dc2626;
+}
+
 .profile-nav-icon {
     width: 20px;
     height: 20px;
+    flex-shrink: 0;
 }
 
-/* Main Content Area */
+.nav-badge {
+    font-size: 9px;
+    padding: 2px 5px;
+    border-radius: 4px;
+    margin-left: auto;
+    color: white;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.profile-nav-separator {
+    height: 1px;
+    background: var(--border-default);
+    margin: 8px 0;
+}
+
+/* ── Main Content Area ───────────────────── */
 .profile-content {
     display: flex;
     flex-direction: column;
     gap: 32px;
+    min-width: 0;
 }
 
 .profile-section-title {
     font-size: 24px;
     font-weight: 800;
-    color: var(--gray-900);
+    color: var(--text-primary);
     margin-bottom: 24px;
     display: flex;
     align-items: center;
     gap: 12px;
 }
 
-/* Stats Grid */
+/* ── Stats Grid ──────────────────────────── */
 .profile-stats {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
-    margin-bottom: 32px;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    margin-bottom: 24px;
 }
 
 .stat-card {
-    background: white;
+    background: var(--bg-card);
     padding: 20px;
     border-radius: 16px;
     border: 1px solid var(--border-default);
     display: flex;
     flex-direction: column;
     gap: 8px;
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow 0.2s ease;
+}
+
+.stat-card:hover {
+    box-shadow: var(--shadow-md);
 }
 
 .stat-label {
@@ -175,7 +226,7 @@
 .stat-value {
     font-size: 24px;
     font-weight: 800;
-    color: var(--gray-900);
+    color: var(--text-primary);
 }
 
 .stat-trend {
@@ -185,22 +236,111 @@
     gap: 4px;
 }
 
-.trend-up {
-    color: var(--success-600);
+.trend-up  { color: var(--success-500); }
+.trend-down { color: #dc2626; }
+
+/* ── Account Card ────────────────────────── */
+.profile-account-card {
+    padding: 32px;
 }
 
-.trend-down {
-    color: var(--error-500);
+.profile-account-title {
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--text-primary);
+    margin-bottom: 24px;
 }
 
-/* Forms */
+.profile-field-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 4px;
+    display: block;
+}
+
+.profile-field-input {
+    width: 100%;
+    font-size: 14px;
+    font-weight: 500;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid var(--border-default);
+    transition: all 0.2s ease;
+}
+
+.profile-field-input:disabled {
+    opacity: 0.7;
+    cursor: default;
+}
+
+.profile-field-input:not(:disabled):focus {
+    outline: none;
+    border-color: var(--primary-400);
+    box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+    background: var(--bg-card);
+}
+
+.profile-field-value {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary);
+    padding: 8px 0;
+}
+
+.profile-action-btn {
+    background: var(--gradient-primary);
+    color: white;
+    padding: 8px 24px;
+    border-radius: 9999px;
+    font-size: 12px;
+    font-weight: 600;
+    margin-top: 32px;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    border: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.profile-action-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(249, 115, 22, 0.3);
+}
+
+.profile-new-btn {
+    background: var(--gradient-primary);
+    color: white;
+    padding: 8px 16px;
+    border-radius: 9999px;
+    font-size: 12px;
+    font-weight: 600;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    border: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.profile-new-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(249, 115, 22, 0.3);
+}
+
+/* ── Forms ───────────────────────────────── */
 .profile-form-grid {
     display: grid;
     grid-template-columns: 1fr;
     gap: 20px;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 640px) {
     .profile-form-grid {
         grid-template-columns: repeat(2, 1fr);
     }
@@ -215,33 +355,162 @@
 .form-label {
     font-size: 13px;
     font-weight: 600;
-    color: var(--gray-700);
+    color: var(--text-secondary);
 }
 
 .form-input {
     padding: 12px 16px;
     border: 1px solid var(--border-default);
     border-radius: 12px;
-    background: var(--gray-50);
+    background: var(--bg-secondary);
     font-size: 14px;
-    color: var(--gray-900);
+    color: var(--text-primary);
     transition: all 0.2s ease;
 }
 
+.form-input::placeholder { color: var(--text-muted); }
+
 .form-input:focus {
     outline: none;
-    background: white;
+    background: var(--bg-card);
     border-color: var(--primary-400);
     box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.1);
 }
 
-/* Connected Apps List */
+/* ── Item Rows (workflows, apps, typeform) ── */
+.profile-row {
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-radius: 16px;
+    padding: 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-row:hover {
+    border-color: var(--border-hover);
+    box-shadow: var(--shadow-sm);
+}
+
+.profile-row-name {
+    font-weight: 500;
+    font-size: 14px;
+    color: var(--text-primary);
+}
+
+.profile-row-meta {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 4px;
+}
+
+/* ── Status Pills ────────────────────────── */
+.status-pill {
+    padding: 4px 14px;
+    border-radius: 9999px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border: none;
+}
+
+.status-pill-active {
+    background: rgba(16, 185, 129, 0.12);
+    color: #10b981;
+}
+
+.status-pill-active:hover {
+    background: rgba(16, 185, 129, 0.2);
+}
+
+.status-pill-paused {
+    background: var(--bg-secondary);
+    color: var(--text-muted);
+    border: 1px solid var(--border-default);
+}
+
+.status-pill-paused:hover {
+    background: var(--bg-hover);
+}
+
+/* ── Panel (info/empty sections) ─────────── */
+.profile-panel {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-default);
+    border-radius: 24px;
+    padding: 32px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.profile-panel-icon {
+    color: var(--text-muted);
+}
+
+.profile-panel-title {
+    font-weight: 500;
+    font-size: 16px;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.profile-panel-text {
+    color: var(--text-secondary);
+    font-size: 14px;
+    margin: 0;
+}
+
+/* ── Data Card ───────────────────────────── */
+.profile-data-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-radius: 16px;
+    padding: 24px;
+    overflow: hidden;
+}
+
+.profile-data-card-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 8px;
+}
+
+.profile-data-card-value {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+/* ── Code/pre display ────────────────────── */
+.profile-pre {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--text-secondary);
+    overflow: auto;
+    max-height: 400px;
+    white-space: pre-wrap;
+    word-break: break-all;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    padding: 12px;
+}
+
+/* ── Connected Apps List ─────────────────── */
 .app-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 16px;
-    background: var(--gray-50);
+    background: var(--bg-secondary);
     border: 1px solid var(--border-default);
     border-radius: 12px;
     margin-bottom: 12px;
@@ -260,23 +529,20 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
 }
 
-.app-icon.pera {
-    background: #ffeebb;
-    color: #d97706;
-}
+.app-icon.pera  { background: #ffeebb; color: #d97706; }
+.app-icon.defly { background: #ede9fe; color: #7c3aed; }
 
-.app-icon.defly {
-    background: #ede9fe;
-    color: #7c3aed;
-}
+[data-theme='dark'] .app-icon.pera  { background: rgba(217,119,6,0.2); color: #fbbf24; }
+[data-theme='dark'] .app-icon.defly { background: rgba(124,58,237,0.2); color: #a78bfa; }
 
 .app-address {
-    font-family: var(--font-mono);
+    font-family: 'JetBrains Mono', monospace;
     font-size: 13px;
     font-weight: 500;
-    color: var(--gray-600);
+    color: var(--text-secondary);
 }
 
 .app-badge {
@@ -292,15 +558,148 @@
     color: var(--primary-700);
 }
 
+[data-theme='dark'] .app-badge.primary {
+    background: rgba(249, 115, 22, 0.15);
+    color: var(--primary-400);
+}
+
 .action-btn {
     padding: 8px;
     color: var(--text-muted);
     border-radius: 6px;
     transition: all 0.2s ease;
+    background: transparent;
+    cursor: pointer;
 }
 
 .action-btn:hover {
-    background: white;
-    color: var(--error-500);
+    background: var(--bg-hover);
+    color: #ef4444;
     box-shadow: var(--shadow-sm);
+}
+
+/* ── Save message ────────────────────────── */
+.profile-save-msg {
+    font-size: 12px;
+    margin-top: 8px;
+    color: var(--success-500);
+}
+
+/* ═══════════════════════════════════════════
+   RESPONSIVE
+═══════════════════════════════════════════ */
+
+@media (max-width: 1024px) {
+    .profile-container {
+        max-width: 720px;
+    }
+}
+
+@media (max-width: 768px) {
+    .profile-page {
+        padding-top: 80px;
+        padding-bottom: 40px;
+    }
+
+    .profile-container {
+        padding: 0 16px;
+        gap: 20px;
+        max-width: 100%;
+    }
+
+    .profile-section-title {
+        font-size: 20px;
+        margin-bottom: 16px;
+    }
+
+    .profile-card {
+        padding: 20px;
+        border-radius: 16px;
+    }
+
+    .profile-account-card {
+        padding: 20px;
+    }
+
+    .profile-stats {
+        gap: 12px;
+        margin-bottom: 16px;
+    }
+
+    .stat-value {
+        font-size: 20px;
+    }
+
+    /* Sidebar nav → horizontal scrollable row on mobile */
+    .profile-nav {
+        flex-direction: row;
+        overflow-x: auto;
+        gap: 6px;
+        padding-bottom: 4px;
+        scrollbar-width: none;
+    }
+
+    .profile-nav::-webkit-scrollbar { display: none; }
+
+    .profile-nav-btn {
+        white-space: nowrap;
+        padding: 8px 12px;
+        font-size: 13px;
+        flex-shrink: 0;
+    }
+
+    .profile-nav-separator { display: none; }
+
+    .profile-panel {
+        padding: 24px 16px;
+    }
+}
+
+@media (max-width: 480px) {
+    .profile-page {
+        padding-top: 72px;
+        padding-bottom: 32px;
+    }
+
+    .profile-container {
+        padding: 0 12px;
+        gap: 16px;
+    }
+
+    .profile-section-title {
+        font-size: 18px;
+    }
+
+    .profile-stats {
+        grid-template-columns: 1fr;
+    }
+
+    .profile-card {
+        padding: 16px;
+        border-radius: 14px;
+    }
+
+    .profile-account-card {
+        padding: 16px;
+    }
+
+    .profile-avatar {
+        width: 80px;
+        height: 80px;
+        font-size: 26px;
+    }
+
+    .profile-name {
+        font-size: 18px;
+    }
+
+    .profile-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .profile-row .status-pill {
+        align-self: flex-start;
+    }
 }

--- a/src/styles/RunHistoryPage.css
+++ b/src/styles/RunHistoryPage.css
@@ -1,0 +1,272 @@
+/* ============================
+   Run History Page Styles
+   ============================ */
+
+.runhistory-page {
+    background: var(--bg-primary);
+    min-height: 100vh;
+    padding: 40px 20px;
+    font-family: 'Inter', sans-serif;
+}
+
+.runhistory-inner {
+    max-width: 1000px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+/* ── Header ─────────────────────── */
+.runhistory-header h1 {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0 0 8px;
+}
+
+.runhistory-header p {
+    color: var(--text-secondary);
+    margin: 0;
+    font-size: 14px;
+}
+
+/* ── Cards ──────────────────────── */
+.runhistory-card {
+    background: var(--bg-card);
+    padding: 24px;
+    border-radius: 12px;
+    border: 1px solid var(--border-default);
+    box-shadow: var(--shadow-sm);
+}
+
+.runhistory-card h2 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 20px;
+}
+
+/* ── Table ──────────────────────── */
+.runhistory-table-card {
+    background: var(--bg-card);
+    border-radius: 12px;
+    border: 1px solid var(--border-default);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+}
+
+.runhistory-table-header {
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border-default);
+}
+
+.runhistory-table-header h2 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.runhistory-table-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.runhistory-table {
+    width: 100%;
+    text-align: left;
+    border-collapse: collapse;
+}
+
+.runhistory-table thead tr {
+    background: var(--bg-secondary);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+}
+
+.runhistory-table thead th {
+    padding: 12px 24px;
+    font-weight: 600;
+    border-bottom: 1px solid var(--border-default);
+    white-space: nowrap;
+}
+
+.runhistory-table tbody {
+    font-size: 14px;
+    color: var(--text-primary);
+}
+
+.runhistory-table tbody tr {
+    border-bottom: 1px solid var(--border-default);
+    transition: background 0.15s ease;
+}
+
+.runhistory-table tbody tr:last-child {
+    border-bottom: none;
+}
+
+.runhistory-table tbody tr:hover {
+    background: var(--bg-hover);
+}
+
+.runhistory-table td {
+    padding: 16px 24px;
+    vertical-align: middle;
+}
+
+.runhistory-ts {
+    white-space: nowrap;
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.runhistory-workflow {
+    font-weight: 500;
+}
+
+/* ── Status Badge ────────────────── */
+.runhistory-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.runhistory-badge.success {
+    background: rgba(16, 185, 129, 0.12);
+    color: #10b981;
+}
+
+.runhistory-badge.failed {
+    background: rgba(239, 68, 68, 0.12);
+    color: #ef4444;
+}
+
+[data-theme='dark'] .runhistory-badge.success {
+    background: rgba(16, 185, 129, 0.18);
+    color: #34d399;
+}
+
+[data-theme='dark'] .runhistory-badge.failed {
+    background: rgba(239, 68, 68, 0.18);
+    color: #f87171;
+}
+
+/* ── Payload cell ────────────────── */
+.runhistory-payload {
+    max-width: 280px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-family: 'JetBrains Mono', monospace;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+}
+
+.runhistory-payload.error {
+    background: rgba(239, 68, 68, 0.08);
+    color: #ef4444;
+}
+
+[data-theme='dark'] .runhistory-payload.error {
+    background: rgba(239, 68, 68, 0.15);
+    color: #f87171;
+}
+
+/* ── Retry Button ────────────────── */
+.runhistory-retry {
+    padding: 4px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    border: 1px solid var(--border-default);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.runhistory-retry:hover:not(:disabled) {
+    border-color: var(--primary-400);
+    color: var(--primary-500);
+    background: var(--bg-hover);
+}
+
+.runhistory-retry:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* ── Empty / Loading ─────────────── */
+.runhistory-empty {
+    padding: 32px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.runhistory-chart-empty {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.runhistory-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    color: var(--text-muted);
+    font-size: 16px;
+}
+
+/* ─────────────────────────────────
+   RESPONSIVE
+───────────────────────────────── */
+
+@media (max-width: 768px) {
+    .runhistory-page {
+        padding: 24px 16px;
+    }
+
+    .runhistory-card {
+        padding: 16px;
+    }
+
+    .runhistory-table-header {
+        padding: 14px 16px;
+    }
+
+    .runhistory-table thead th,
+    .runhistory-table td {
+        padding: 12px 16px;
+    }
+
+    .runhistory-payload {
+        max-width: 180px;
+    }
+}
+
+@media (max-width: 480px) {
+    .runhistory-page {
+        padding: 20px 12px;
+    }
+
+    .runhistory-header h1 {
+        font-size: 20px;
+    }
+
+    .runhistory-inner {
+        gap: 16px;
+    }
+}


### PR DESCRIPTION
## Summary

- Fix dark mode in ProfilePage: all hardcoded white/gray CSS values replaced with CSS variable tokens; dark overrides added for badges, nav active state, status pills, app icons
- Fix ProfilePage responsiveness: sidebar nav becomes horizontal scroll row on mobile (≤768px), stats grid single-column at 480px, padding scales down
- Fix EmptyState dark mode: replace dead Tailwind-ish classes and hardcoded g-black button with CSS variable styles
- Fix RunHistoryPage dark mode + responsiveness: extract all hardcoded inline light-mode styles into new RunHistoryPage.css using the design system CSS variables; mobile breakpoints for table and layout

## Test plan
- [ ] Toggle dark mode on /profile — cards, nav, stat cards, panels all adapt
- [ ] Resize to 375px — sidebar nav scrolls horizontally, stats stack to 1 column
- [ ] Toggle dark mode on /run-history — table, badges, retry button, chart tooltip all adapt
- [ ] Resize /run-history to mobile — table scrolls horizontally, layout adjusts

Closes #126
Closes #127