### PR TITLE
fix(#143): replace wildcard CORS with explicit origin allowlist in auth and backend servers

### DIFF
--- a/flowconnect/auth-backend/auth-server.js
+++ b/flowconnect/auth-backend/auth-server.js
@@ -56,8 +56,21 @@ const GOOGLE_OAUTH_SCOPES = [
 const googleOauthStateCache = new Map();
 let googlePollingInProgress = false;
 
+const CORS_ORIGIN = process.env.CORS_ORIGIN || "";
+const corsOrigins = CORS_ORIGIN
+  ? CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
+  : [];
+
 const app = express();
-app.use(cors());
+app.use(
+  cors({
+    // Restrict to explicit origins from the environment variable.
+    // cors() with no arguments defaults to Access-Control-Allow-Origin: *
+    // which allows any website to make requests to this server.
+    origin: corsOrigins.length > 0 ? corsOrigins : false,
+    credentials: true,
+  })
+);
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 

--- a/flowconnect/backend/server.js
+++ b/flowconnect/backend/server.js
@@ -9,8 +9,18 @@ const analyticsRouter = require("./routes/analytics.js");
 const app = express();
 const server = http.createServer(app);
 
+const socketCorsOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
+  : [];
+
 const io = new SocketIO(server, {
-  cors: { origin: "*" },
+  // Replace the wildcard origin with an explicit allowlist from the environment.
+  // origin: "*" allows any website to establish a Socket.IO connection, which
+  // combined with cookie-based authentication enables CSRF attacks.
+  cors: {
+    origin: socketCorsOrigins.length > 0 ? socketCorsOrigins : false,
+    credentials: true,
+  },
 });
 
 initSocket(io);


### PR DESCRIPTION
## Summary

Both backend servers used unrestricted CORS configurations. `auth-server.js` called `cors()` with no arguments (defaults to `Access-Control-Allow-Origin: *`). `backend/server.js` registered Socket.IO with `{ origin: '*' }`. Wildcard CORS combined with cookie-based or token-based authentication allows any malicious website to make cross-origin requests using the victim's active session.

Closes #143

## Root Cause

```js
// auth-server.js
app.use(cors());  // Access-Control-Allow-Origin: *

// backend/server.js
const io = new SocketIO(server, {
  cors: { origin: "*" },
});
```

Both configurations allow any origin to send requests without restriction.

## Changes

**`flowconnect/auth-backend/auth-server.js`**

Replaced `cors()` with an explicit allowlist built from the `CORS_ORIGIN` environment variable:

```js
const CORS_ORIGIN = process.env.CORS_ORIGIN || "";
const corsOrigins = CORS_ORIGIN
  ? CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
  : [];

app.use(cors({
  origin: corsOrigins.length > 0 ? corsOrigins : false,
  credentials: true,
}));
```

When `CORS_ORIGIN` is not set the origin is `false` (deny all cross-origin requests).

**`flowconnect/backend/server.js`**

Applied the same pattern to Socket.IO:

```js
const socketCorsOrigins = process.env.CORS_ORIGIN
  ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
  : [];

const io = new SocketIO(server, {
  cors: {
    origin: socketCorsOrigins.length > 0 ? socketCorsOrigins : false,
    credentials: true,
  },
});
```

## Configuration

Set `CORS_ORIGIN` to the frontend origin(s):
```
CORS_ORIGIN=http://localhost:5173
# For multiple origins:
CORS_ORIGIN=https://app.example.com,https://staging.example.com
```

## How to Test

1. Start both servers with `CORS_ORIGIN=http://localhost:5173`
2. Make a cross-origin request from `localhost:5173` and confirm it succeeds
3. Make a cross-origin request from a different origin and confirm it is blocked with a CORS error
4. Start without `CORS_ORIGIN` set and confirm all cross-origin requests are blocked

## Checklist

- [x] `cors()` wildcard removed from `auth-server.js`
- [x] Socket.IO `origin: '*'` removed from `backend/server.js`
- [x] Both servers use the same `CORS_ORIGIN` environment variable
- [x] Default behaviour when unset is to deny all cross-origin requests
- [x] No new dependencies