### PR TITLE
fix(#144): add API key authentication and rate limiting to POST /api/sms

### DIFF
--- a/src/server/fast2sms-route.js
+++ b/src/server/fast2sms-route.js
@@ -7,7 +7,42 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const router = express.Router();
 
-router.post("/sms", async (req, res) => {
+// Lightweight in-process rate limiter for the SMS endpoint.
+// Keyed by IP address; allows at most 5 requests per 15 minutes per IP.
+const smsRateLimitStore = new Map();
+const SMS_RATE_LIMIT_MAX = 5;
+const SMS_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+function smsRateLimiter(req, res, next) {
+  const forwarded = req.headers["x-forwarded-for"];
+  const ip = (Array.isArray(forwarded) ? forwarded[0] : String(forwarded || "").split(",")[0])?.trim() || req.ip || "unknown";
+  const now = Date.now();
+  const entry = smsRateLimitStore.get(ip);
+  if (!entry || now - entry.windowStart >= SMS_RATE_LIMIT_WINDOW_MS) {
+    smsRateLimitStore.set(ip, { count: 1, windowStart: now });
+    return next();
+  }
+  if (entry.count >= SMS_RATE_LIMIT_MAX) {
+    return res.status(429).json({ error: "Too many SMS requests. Please wait before trying again." });
+  }
+  entry.count += 1;
+  return next();
+}
+
+// Require a static API key in the Authorization header before accepting
+// any SMS send requests. Without this check any anonymous caller can
+// exhaust the Fast2SMS credit balance by flooding the endpoint.
+function requireApiKey(req, res, next) {
+  const authHeader = req.headers["authorization"] || "";
+  const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+  const expectedKey = process.env.AUTH_API_KEY || "";
+  if (!expectedKey || token !== expectedKey) {
+    return res.status(401).json({ error: "Authentication required" });
+  }
+  return next();
+}
+
+router.post("/sms", requireApiKey, smsRateLimiter, async (req, res) => {
   const { numbers, message, sender_id } = req.body;
 
   if (!numbers || !message) {


### PR DESCRIPTION
## Summary

`src/server/fast2sms-route.js` registered a public SMS-sending endpoint with no authentication and no rate limiting. Any anonymous caller could POST to `/api/sms` and trigger outbound SMS messages at unlimited speed, exhausting the Fast2SMS account credit balance without any restriction.

Closes #144

## Root Cause

```js
// Before - no auth, no rate limit
router.post("/sms", async (req, res) => {
  const { numbers, message, sender_id } = req.body;
  // ... immediately sends SMS
});
```

## Changes

**`src/server/fast2sms-route.js`**

**`requireApiKey` middleware**

Checks the `Authorization: Bearer <token>` header against the `AUTH_API_KEY` environment variable before any SMS processing begins:

```js
function requireApiKey(req, res, next) {
  const token = (req.headers["authorization"] || "").startsWith("Bearer ")
    ? req.headers["authorization"].slice(7) : "";
  if (!process.env.AUTH_API_KEY || token !== process.env.AUTH_API_KEY) {
    return res.status(401).json({ error: "Authentication required" });
  }
  return next();
}
```

**`smsRateLimiter` middleware**

Limits each IP address to 5 SMS requests per 15-minute window using an in-process Map:

```js
function smsRateLimiter(req, res, next) {
  // ... 5 requests per 15 minutes per IP, 429 on excess
}
```

Both middlewares are applied to the `POST /sms` route:
```js
router.post("/sms", requireApiKey, smsRateLimiter, async (req, res) => { ... });
```

## Configuration

Generate and set an API key:
```bash
node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
# Then set: AUTH_API_KEY=<output>
```

Callers must include the header: `Authorization: Bearer <AUTH_API_KEY>`

## How to Test

1. POST to `/api/sms` without the `Authorization` header and confirm 401 is returned
2. POST with an incorrect token and confirm 401 is returned
3. POST with the correct `AUTH_API_KEY` token and confirm the SMS is sent
4. Send 6 requests in quick succession and confirm the 6th returns 429

## Checklist

- [x] Authentication check applied before SMS processing
- [x] Rate limiter applied after authentication
- [x] 429 returned with a descriptive error on rate limit exceeded
- [x] `AUTH_API_KEY` controls the allowed token server-side
- [x] No new runtime dependencies