### PR TITLE
fix(notifications): add authentication and ownership checks to notification routes [NSoC'26]

### DIFF
--- a/flowconnect/backend/middleware/auth.js
+++ b/flowconnect/backend/middleware/auth.js
@@ -1,0 +1,30 @@
+const jwt = require("jsonwebtoken");
+
+/**
+ * Verify the Bearer JWT sent in the Authorization header.
+ * Attaches the decoded payload to req.user on success.
+ * Returns 401 if the header is absent or the token is invalid.
+ */
+const authenticateUser = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "Authentication required." });
+  }
+
+  const token = authHeader.split(" ")[1];
+  const secret = process.env.JWT_SECRET;
+
+  if (!secret) {
+    console.error("JWT_SECRET environment variable is not set.");
+    return res.status(500).json({ error: "Server configuration error." });
+  }
+
+  try {
+    req.user = jwt.verify(token, secret);
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: "Invalid or expired token." });
+  }
+};
+
+module.exports = { authenticateUser };

--- a/flowconnect/backend/routes/notifications.js
+++ b/flowconnect/backend/routes/notifications.js
@@ -1,20 +1,47 @@
 const router = require("express").Router();
 const Notification = require("../models/Notification");
+const { authenticateUser } = require("../middleware/auth");
 
-// GET all notifications
-router.get("/:userId", async (req, res) => {
-  const data = await Notification.find({ userId: req.params.userId })
-    .sort({ createdAt: -1 });
+// GET notifications for a specific user.
+// Requires authentication and enforces that the authenticated user can only
+// retrieve their own notifications. Without these guards any caller could
+// enumerate another user's notification history by guessing their user ID.
+router.get("/:userId", authenticateUser, async (req, res) => {
+  if (req.user.id !== req.params.userId && req.user.userId !== req.params.userId) {
+    return res.status(403).json({ error: "Access denied." });
+  }
 
-  res.json(data);
+  try {
+    const data = await Notification.find({ userId: req.params.userId })
+      .sort({ createdAt: -1 });
+    res.json(data);
+  } catch (err) {
+    console.error("Error fetching notifications:", err);
+    res.status(500).json({ error: "Failed to fetch notifications." });
+  }
 });
 
-// MARK as read
-router.put("/:id/read", async (req, res) => {
-  await Notification.findByIdAndUpdate(req.params.id, {
-    isRead: true,
-  });
-  res.send("Marked as read");
+// MARK a notification as read.
+// Requires authentication and verifies the caller owns the notification
+// before updating it.
+router.put("/:id/read", authenticateUser, async (req, res) => {
+  try {
+    const notification = await Notification.findById(req.params.id);
+    if (!notification) {
+      return res.status(404).json({ error: "Notification not found." });
+    }
+
+    const callerId = req.user.id || req.user.userId;
+    if (notification.userId !== callerId) {
+      return res.status(403).json({ error: "Access denied." });
+    }
+
+    await Notification.findByIdAndUpdate(req.params.id, { isRead: true });
+    res.json({ success: true });
+  } catch (err) {
+    console.error("Error marking notification as read:", err);
+    res.status(500).json({ error: "Failed to update notification." });
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
## Description

`GET /:userId` and `PUT /:id/read` in `flowconnect/backend/routes/notifications.js` had no authentication middleware. Any unauthenticated HTTP caller could retrieve another user's full notification history by guessing their user ID, and mark any notification as read without any ownership check.

## Changes Made

| File | Change |
|---|---|
| `flowconnect/backend/middleware/auth.js` | New shared JWT middleware that verifies the Bearer token from the Authorization header using `JWT_SECRET` |
| `flowconnect/backend/routes/notifications.js` | `GET /:userId` now requires authentication and returns 403 if the caller's user ID does not match the requested `userId` parameter |
| `flowconnect/backend/routes/notifications.js` | `PUT /:id/read` now requires authentication, fetches the notification, and returns 403 if the caller does not own it |

## Testing Done

- `GET /api/notifications/{userId}` with no Authorization header returns 401.
- `GET /api/notifications/{userId}` with a valid token for a different user returns 403.
- `PUT /api/notifications/{id}/read` with a valid token not owning that notification returns 403.
- Normal read and mark-as-read flows work correctly for the owning user.

## Checklist

- [x] No merge conflicts with main
- [x] No em dashes or double hyphens
- [x] Changes focused on the reported surface

Closes #156