### PR TITLE
fix(analytics): add authentication middleware to GET /api/dashboard/analytics [NSoC'26]

### DIFF
--- a/flowconnect/backend/routes/analytics.js
+++ b/flowconnect/backend/routes/analytics.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { Pool } = require('pg');
+const { authenticateUser } = require('../middleware/auth');
 const router = express.Router();
 
 // PostgreSQL connection pool
@@ -11,7 +12,7 @@ const pool = new Pool({
   port: process.env.DB_PORT || 5432,
 });
 
-router.get('/analytics', async (req, res) => {
+router.get('/analytics', authenticateUser, async (req, res) => {
   try {
     const { dateRange = '30days' } = req.query;
     


### PR DESCRIPTION
## Description

`GET /api/dashboard/analytics` had no authentication middleware. Any unauthenticated caller could retrieve workspace analytics: total workflow count, active workflows, execution history, success/failure rates, most active flows, and recent activity logs.

## Changes Made

| File | Change |
|---|---|
| `flowconnect/backend/routes/analytics.js` | Added `authenticateUser` middleware to the GET `/analytics` handler |

The `authenticateUser` middleware was introduced in PR #163 (fix for #156).

## Testing Done

- `GET /api/dashboard/analytics` with no Authorization header returns 401.
- `GET /api/dashboard/analytics` with a valid Bearer token returns the analytics data normally.

## Checklist

- [x] No merge conflicts with main
- [x] No em dashes or double hyphens
- [x] Changes focused on the reported surface

Closes #160