### PR TITLE
fix(security): move Notion API key to backend proxy

### DIFF
--- a/flowconnect/backend/routes/notion.js
+++ b/flowconnect/backend/routes/notion.js
@@ -1,0 +1,68 @@
+const express = require("express");
+const axios = require("axios");
+
+const router = express.Router();
+
+// SECURITY: All Notion API calls are proxied through this backend endpoint.
+// The actual NOTION_API_KEY is stored securely in backend environment variables
+// and never sent to the frontend. This prevents credential exposure in:
+// - Browser DevTools and source maps
+// - Network inspection tools
+// - Client-side caching or localStorage
+// - Build artifacts
+
+const NOTION_API_KEY = process.env.NOTION_API_KEY;
+const NOTION_BASE_URL = "https://api.notion.com/v1";
+
+if (!NOTION_API_KEY) {
+  console.warn("NOTION_API_KEY is not set. Notion integration will be unavailable.");
+}
+
+// Proxy endpoint: forwards Notion API requests from frontend to Notion API,
+// injecting the server-side API key. Frontend never sees the key.
+router.post("/proxy", async (req, res) => {
+  try {
+    if (!NOTION_API_KEY) {
+      return res.status(503).json({ error: "Notion integration not configured" });
+    }
+
+    const { endpoint, body } = req.body;
+    const method = req.headers["x-notion-method"]?.toLowerCase() || "get";
+
+    if (!endpoint) {
+      return res.status(400).json({ error: "Missing endpoint parameter" });
+    }
+
+    const url = `${NOTION_BASE_URL}/${endpoint}`;
+
+    const axiosConfig = {
+      method,
+      url,
+      headers: {
+        Authorization: `Bearer ${NOTION_API_KEY}`,
+        "Notion-Version": "2024-10-08",
+        "Content-Type": "application/json",
+      },
+    };
+
+    if (body && (method === "post" || method === "patch" || method === "put")) {
+      axiosConfig.data = body;
+    }
+
+    const response = await axios(axiosConfig);
+    res.json(response.data);
+  } catch (error) {
+    console.error("Notion proxy error:", error.message);
+
+    if (error.response) {
+      return res.status(error.response.status).json({
+        error: error.response.data?.message || "Notion API error",
+        code: error.response.data?.code || "UNKNOWN",
+      });
+    }
+
+    res.status(500).json({ error: "Notion proxy request failed" });
+  }
+});
+
+module.exports = router;

--- a/src/api/notion.ts
+++ b/src/api/notion.ts
@@ -1,28 +1,40 @@
 import { http } from './httpClient'
 
-const NOTION_API_KEY = import.meta.env.VITE_NOTION_API_KEY
-const BASE_URL = 'https://api.notion.com/v1'
+// SECURITY FIX: Never expose API keys in frontend code. All Notion API
+// calls are now proxied through the backend, which holds the actual
+// NOTION_API_KEY securely in environment variables that are never sent
+// to the client. This prevents credential leakage in source maps, DevTools,
+// or network inspection.
+
+const BACKEND_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+const NOTION_PROXY_BASE = `${BACKEND_BASE}/api/integrations/notion`
 
 async function notionRequest(
   method: string,
   endpoint: string,
   body?: object
 ) {
-  const url = `${BASE_URL}/${endpoint}`
+  // All requests go through the backend proxy endpoint, which handles
+  // Notion authentication securely with the API key stored server-side.
+  const proxyEndpoint = `${NOTION_PROXY_BASE}/proxy`
   const options: any = {
     headers: {
-      Authorization: `Bearer ${NOTION_API_KEY}`,
-      'Notion-Version': '2024-10-08', // Use latest Notion API version
+      'X-Notion-Endpoint': endpoint,
+      'X-Notion-Method': method,
     },
-    skipAuth: true, // Notion has its own auth
   }
 
-  if (method === 'GET') {
-    return http.get(url, options)
-  } else if (method === 'POST') {
-    return http.post(url, body, options)
-  } else if (method === 'PATCH') {
-    return http.put(url, body, options)
+  try {
+    if (method === 'GET') {
+      return http.get(proxyEndpoint, { ...options, params: { endpoint } })
+    } else if (method === 'POST') {
+      return http.post(proxyEndpoint, { endpoint, body }, options)
+    } else if (method === 'PATCH') {
+      return http.put(proxyEndpoint, { endpoint, body }, options)
+    }
+  } catch (error) {
+    console.error('Notion proxy request failed:', error)
+    throw error
   }
 }
 


### PR DESCRIPTION
**Closes #167**

Frontend code loaded NOTION_API_KEY from environment and used it directly in API calls. The key is embedded in JavaScript bundles, visible in DevTools, and exposed to all users.

**Fix:** Created backend proxy at /api/integrations/notion/proxy that securely handles Notion authentication server-side. Frontend never sees the actual API key.