### PR TITLE
feat: add reusable activity feed component to dashboard

### DIFF
--- a/src/components/dashboard/ActivityFeed.tsx
+++ b/src/components/dashboard/ActivityFeed.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+
+export interface ActivityItem {
+    id: string;
+    name: string;
+    timestamp: string;
+    status: string;
+    executionCount: number;
+}
+
+interface ActivityFeedProps {
+    activities: ActivityItem[];
+}
+
+const ITEMS_PER_PAGE = 5;
+
+export default function ActivityFeed({
+    activities,
+}: ActivityFeedProps) {
+    const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE);
+
+    const visibleActivities = activities.slice(0, visibleCount);
+
+    const formatRelativeTime = (timestamp: string) => {
+        const now = new Date().getTime();
+        const activityTime = new Date(timestamp).getTime();
+
+        const diffMinutes = Math.floor(
+            (now - activityTime) / (1000 * 60)
+        );
+
+        if (diffMinutes < 1) return "Just now";
+        if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+        const diffHours = Math.floor(diffMinutes / 60);
+
+        if (diffHours < 24) return `${diffHours}h ago`;
+
+        const diffDays = Math.floor(diffHours / 24);
+
+        return `${diffDays}d ago`;
+    };
+
+    if (!activities.length) {
+        return (
+            <div className="recent-activity">
+                <h3>Activity Feed</h3>
+
+                <div className="no-activity">
+                    No activity yet. Workflow executions will appear here.
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="recent-activity">
+            <h3>Activity Feed</h3>
+
+            <div className="activity-list">
+                {visibleActivities.map((item) => (
+                    <div key={item.id} className="activity-item">
+                        <div className={`status-dot ${item.status}`} />
+
+                        <div className="activity-info">
+                            <p className="activity-name">{item.name}</p>
+
+                            <p className="activity-time">
+                                {formatRelativeTime(item.timestamp)} •{" "}
+                                {new Date(item.timestamp).toLocaleString()}
+                            </p>
+                        </div>
+
+                        <span className="exec-count">
+                            {item.executionCount} runs
+                        </span>
+                    </div>
+                ))}
+            </div>
+
+            {visibleCount < activities.length && (
+                <button
+                    className="load-more-btn"
+                    onClick={() =>
+                        setVisibleCount((prev) => prev + ITEMS_PER_PAGE)
+                    }
+                >
+                    Load More
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { ArrowLeft, BarChart3, TrendingUp, Activity } from 'lucide-react'
+import { ArrowLeft } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import toast from 'react-hot-toast'
 import {
@@ -10,8 +10,8 @@ import {
 import { getDashboardAnalytics, type DashboardAnalytics } from '../api/dashboard'
 import Navbar from '../components/common/Navbar'
 import '../styles/DashboardPage.css'
+import ActivityFeed from "../components/dashboard/ActivityFeed";
 
-const COLORS = ['#10b981', '#ef4444']
 
 function DashboardPage() {
   const [data, setData] = useState<DashboardAnalytics | null>(null)
@@ -51,120 +51,104 @@ function DashboardPage() {
     <>
       <Navbar />
       <div className="dashboard-container">
-      <div className="dashboard-header">
-        <div className="dashboard-header__left">
-          <Link to="/builder" className="dashboard-header__back">
-            <ArrowLeft size={20} />
-          </Link>
-          <h1>Dashboard</h1>
-        </div>
-        <div className="dashboard-filters">
-          <button
-            className={`filter-btn ${dateRange === '7days' ? 'active' : ''}`}
-            onClick={() => setDateRange('7days')}
-          >
-            7 days
-          </button>
-          <button
-            className={`filter-btn ${dateRange === '30days' ? 'active' : ''}`}
-            onClick={() => setDateRange('30days')}
-          >
-            30 days
-          </button>
-          <button
-            className={`filter-btn ${dateRange === 'all' ? 'active' : ''}`}
-            onClick={() => setDateRange('all')}
-          >
-            All time
-          </button>
-        </div>
-      </div>
-
-      <div className="dashboard-stats">
-        <StatCard label="Total Workflows" value={data.summary.totalWorkflows} icon="📊" />
-        <StatCard label="Active Workflows" value={data.summary.activeWorkflows} icon="⚡" />
-        <StatCard label="Total Executions" value={data.summary.totalExecutions} icon="🔄" />
-        <StatCard label="Connected Apps" value={data.summary.connectedApps} icon="🔌" />
-      </div>
-
-      <div className="dashboard-charts">
-        <div className="chart-box chart-full">
-          <h3>Execution History</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <AreaChart data={data.executionHistory}>
-              <defs>
-                <linearGradient id="colorExec" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" />
-              <YAxis />
-              <Tooltip />
-              <Area type="monotone" dataKey="executions" stroke="#3b82f6" fill="url(#colorExec)" />
-            </AreaChart>
-          </ResponsiveContainer>
-        </div>
-
-        <div className="chart-box">
-          <h3>Success Rate</h3>
-          <div className="chart-pie">
-            <ResponsiveContainer width="100%" height={250}>
-              <PieChart>
-                <Pie
-                  data={[
-                    { name: 'Success', value: data.successFailureStats.successful },
-                    { name: 'Failed', value: data.successFailureStats.failed },
-                  ]}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={50}
-                  outerRadius={80}
-                  dataKey="value"
-                >
-                  <Cell fill="#10b981" />
-                  <Cell fill="#ef4444" />
-                </Pie>
-              </PieChart>
-            </ResponsiveContainer>
-            <p className="success-rate">{successRate}%</p>
+        <div className="dashboard-header">
+          <div className="dashboard-header__left">
+            <Link to="/builder" className="dashboard-header__back">
+              <ArrowLeft size={20} />
+            </Link>
+            <h1>Dashboard</h1>
+          </div>
+          <div className="dashboard-filters">
+            <button
+              className={`filter-btn ${dateRange === '7days' ? 'active' : ''}`}
+              onClick={() => setDateRange('7days')}
+            >
+              7 days
+            </button>
+            <button
+              className={`filter-btn ${dateRange === '30days' ? 'active' : ''}`}
+              onClick={() => setDateRange('30days')}
+            >
+              30 days
+            </button>
+            <button
+              className={`filter-btn ${dateRange === 'all' ? 'active' : ''}`}
+              onClick={() => setDateRange('all')}
+            >
+              All time
+            </button>
           </div>
         </div>
 
-        <div className="chart-box">
-          <h3>Most Active Flows</h3>
-          <ResponsiveContainer width="100%" height={250}>
-            <BarChart data={data.mostActiveFlows}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis />
-              <Tooltip />
-              <Bar dataKey="executions" fill="#8b5cf6" radius={[8, 8, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
+        <div className="dashboard-stats">
+          <StatCard label="Total Workflows" value={data.summary.totalWorkflows} icon="📊" />
+          <StatCard label="Active Workflows" value={data.summary.activeWorkflows} icon="⚡" />
+          <StatCard label="Total Executions" value={data.summary.totalExecutions} icon="🔄" />
+          <StatCard label="Connected Apps" value={data.summary.connectedApps} icon="🔌" />
         </div>
-      </div>
 
-      <div className="recent-activity">
-        <h3>Recent Activity</h3>
-        <div className="activity-list">
-          {data.recentActivity.length > 0 ? (
-            data.recentActivity.map((item) => (
-              <div key={item.id} className="activity-item">
-                <div className={`status-dot ${item.status}`}></div>
-                <div className="activity-info">
-                  <p className="activity-name">{item.name}</p>
-                  <p className="activity-time">{new Date(item.timestamp).toLocaleString()}</p>
-                </div>
-                <span className="exec-count">{item.executionCount} runs</span>
-              </div>
-            ))
-          ) : (
-            <p className="no-activity">No recent activity</p>
-          )}
+        <div className="dashboard-charts">
+          <div className="chart-box chart-full">
+            <h3>Execution History</h3>
+            <ResponsiveContainer width="100%" height={300}>
+              <AreaChart data={data.executionHistory}>
+                <defs>
+                  <linearGradient id="colorExec" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
+                    <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis />
+                <Tooltip />
+                <Area type="monotone" dataKey="executions" stroke="#3b82f6" fill="url(#colorExec)" />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="chart-box">
+            <h3>Success Rate</h3>
+            <div className="chart-pie">
+              <ResponsiveContainer width="100%" height={250}>
+                <PieChart>
+                  <Pie
+                    data={[
+                      { name: 'Success', value: data.successFailureStats.successful },
+                      { name: 'Failed', value: data.successFailureStats.failed },
+                    ]}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={50}
+                    outerRadius={80}
+                    dataKey="value"
+                  >
+                    <Cell fill="#10b981" />
+                    <Cell fill="#ef4444" />
+                  </Pie>
+                </PieChart>
+              </ResponsiveContainer>
+              <p className="success-rate">{successRate}%</p>
+            </div>
+          </div>
+
+          <div className="chart-box">
+            <h3>Most Active Flows</h3>
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={data.mostActiveFlows}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="executions" fill="#8b5cf6" radius={[8, 8, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </div>
-      </div>
+
+        <ActivityFeed
+          activities={data.recentActivity}
+        />
       </div>
     </>
   )

--- a/src/styles/DashboardPage.css
+++ b/src/styles/DashboardPage.css
@@ -314,3 +314,16 @@
     font-size: 20px;
   }
 }
+
+.load-more-btn {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.load-more-btn:hover {
+  opacity: 0.9;
+}


### PR DESCRIPTION
## Summary

This PR enhances the Dashboard activity section by introducing a reusable `ActivityFeed` component and improving the activity viewing experience.

### Changes Made

* Created a reusable `ActivityFeed` component
* Replaced inline activity rendering in `DashboardPage`
* Added relative timestamps alongside exact timestamps
* Added "Load More" pagination for activity items
* Improved empty-state UI when no activity exists
* Simplified dashboard activity rendering logic

## Testing

* [x] `npm run dev`
* [ ] `npm run lint` *(currently fails due to existing unrelated lint issues in the repository)*
* [ ] `npm run build`

## Notes

* The repository already contains notification/socket infrastructure that could be leveraged in a future enhancement for real-time activity updates.
* This PR focuses on improving the existing activity section and preparing it for future expansion.
* No backend API changes were required.

Closes #178

